### PR TITLE
Update vitess repo to new github location

### DIFF
--- a/serialization_benchmarks_test.go
+++ b/serialization_benchmarks_test.go
@@ -2,7 +2,7 @@ package goserbench
 
 import (
 	"bytes"
-	vitessbson "code.google.com/p/vitess/go/bson"
+	vitessbson "github.com/youtube/vitess/go/bson"
 	"encoding/gob"
 	"encoding/json"
 	"fmt"


### PR DESCRIPTION
Youtube's vitess project has moved from Google Code to GitHub.  Update the
import line accordingly.
