### PR TITLE
remove go-msgpack from benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This is a test suite for benchmarking various Go serialization methods.
 - [github.com/alecthomas/binary](https://github.com/alecthomas/binary)
 - [github.com/davecgh/go-xdr/xdr](https://github.com/davecgh/go-xdr)
 - [github.com/Sereal/Sereal/Go/sereal](https://github.com/Sereal/Sereal)
-- [github.com/ugorji/go-msgpack](https://github.com/ugorji/go-msgpack)
 - [github.com/ugorji/go/codec](https://github.com/ugorji/go/tree/master/codec)
 - [github.com/vmihailenco/msgpack](https://github.com/vmihailenco/msgpack)
 - [github.com/youtube/vitess/go/bson](https://github.com/youtube/vitess/tree/master/go/bson) *(using the bsongen code generator)*
@@ -60,9 +59,6 @@ type A struct {
 Results on my late 2013 MacBook Pro 15" are:
 
 ```
-BenchmarkUgorjiMsgpackMarshal                500000       3876 ns/op     1326 B/op       21 allocs/op
-BenchmarkUgorjiMsgpackUnmarshal              500000       3541 ns/op      644 B/op       20 allocs/op
-
 BenchmarkVmihailencoMsgpackMarshal          1000000       1682 ns/op      413 B/op        6 allocs/op
 BenchmarkVmihailencoMsgpackUnmarshal        1000000       2012 ns/op      421 B/op       10 allocs/op
 
@@ -113,17 +109,11 @@ VALIDATE=1 go test -bench='.*' ./
 
 Unfortunately, several of the serializers exhibit issues:
 
-1. **(MAJOR)** Ugorji msgpack implementation drops the timezone frome `time.Time`.
-2. **(minor)** BSON drops sub-microsecond precision from `time.Time`.
-3. **(minor)** Vitess BSON drops sub-microsecond precision from `time.Time`.
-4. **(minor)** Ugorji Binc Codec drops the timezone name (eg. "EST" -> "-0500") from `time.Time`.
+1. **(minor)** BSON drops sub-microsecond precision from `time.Time`.
+2. **(minor)** Vitess BSON drops sub-microsecond precision from `time.Time`.
+3. **(minor)** Ugorji Binc Codec drops the timezone name (eg. "EST" -> "-0500") from `time.Time`.
 
 ```
-BenchmarkUgorjiMsgpackMarshal     500000          3678 ns/op        1327 B/op         21 allocs/op
-BenchmarkUgorjiMsgpackUnmarshal --- FAIL: BenchmarkUgorjiMsgpackUnmarshal
-    serialization_benchmarks_test.go:301: unmarshaled object differed:
-        &{d8c7b339f1dd290e 2014-09-26 14:46:03.137970198 +1000 AEST 9894e18711 2 true 0.9013406798206226}
-        &{d8c7b339f1dd290e 2014-09-26 04:46:03.137970198 +0000 UTC 9894e18711 2 true 0.9013406798206226}
 BenchmarkVmihailencoMsgpackMarshal   1000000          1665 ns/op         412 B/op          6 allocs/op
 BenchmarkVmihailencoMsgpackUnmarshal     1000000          3001 ns/op         517 B/op         12 allocs/op
 BenchmarkJsonMarshal     1000000          2843 ns/op         590 B/op          7 allocs/op

--- a/serialization_benchmarks_test.go
+++ b/serialization_benchmarks_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/alecthomas/binary"
 	"github.com/davecgh/go-xdr/xdr"
 	"github.com/philhofer/msgp/msgp"
-	ugorji "github.com/ugorji/go-msgpack"
 	"github.com/ugorji/go/codec"
 	vmihailenco "github.com/vmihailenco/msgpack"
 	vitessbson "github.com/youtube/vitess/go/bson"
@@ -83,21 +82,6 @@ func (m MsgpSerializer) Unmarshal(d []byte, o interface{}) error {
 }
 
 func (m MsgpSerializer) String() string { return "Msgp" }
-
-type UgorjiMsgpackSerializer int
-
-func (m UgorjiMsgpackSerializer) Marshal(o interface{}) []byte {
-	d, _ := ugorji.Marshal(o)
-	return d
-}
-
-func (m UgorjiMsgpackSerializer) Unmarshal(d []byte, o interface{}) error {
-	return ugorji.Unmarshal(d, o, nil)
-}
-
-func (m UgorjiMsgpackSerializer) String() string {
-	return "ugorji-msgpack"
-}
 
 type VmihailencoMsgpackSerializer int
 
@@ -324,13 +308,6 @@ See README.md for details on running the benchmarks.
 `)
 
 }
-func BenchmarkUgorjiMsgpackMarshal(b *testing.B) {
-	benchMarshal(b, UgorjiMsgpackSerializer(0))
-}
-
-func BenchmarkUgorjiMsgpackUnmarshal(b *testing.B) {
-	benchUnmarshal(b, UgorjiMsgpackSerializer(0))
-}
 
 func BenchmarkVmihailencoMsgpackMarshal(b *testing.B) {
 	benchMarshal(b, VmihailencoMsgpackSerializer(0))
@@ -391,12 +368,16 @@ func BenchmarkUgorjiCodecMsgpackUnmarshal(b *testing.B) {
 }
 
 func BenchmarkUgorjiCodecBincMarshal(b *testing.B) {
-	s := NewUgorjiCodecSerializer("binc", &codec.BincHandle{})
+	h := &codec.BincHandle{}
+	h.AsSymbols = codec.AsSymbolNone
+	s := NewUgorjiCodecSerializer("binc", h)
 	benchMarshal(b, s)
 }
 
 func BenchmarkUgorjiCodecBincUnmarshal(b *testing.B) {
-	s := NewUgorjiCodecSerializer("binc", &codec.BincHandle{})
+	h := &codec.BincHandle{}
+	h.AsSymbols = codec.AsSymbolNone
+	s := NewUgorjiCodecSerializer("binc", h)
 	benchUnmarshal(b, s)
 }
 


### PR DESCRIPTION
go-msgpack has been stalled and has been deprecated for over a year. 
The code was moved into go-codec and all development continued there. 
It should not be reflected in this benchmark.

Also, use AsSymbolNone for Binc. 
Binc is either optimized for space (de-duplicate strings) or speed (do not de-duplicate strings). 
For performance comparisons, do not de-duplicate strings; this is in line with most other impls.
