### PR TITLE
Added hprose benchmarks test

### DIFF
--- a/serialization_benchmarks_test.go
+++ b/serialization_benchmarks_test.go
@@ -485,8 +485,8 @@ func BenchmarkGogoprotobufUnmarshal(b *testing.B) {
 		err := proto.Unmarshal(ser[n], o)
 		if err != nil {
 			b.Fatalf("goprotobuf failed to unmarshal: %s (%s)", err, ser[n])
-			// Validate unmarshalled data.
 		}
+		// Validate unmarshalled data.
 		if validate != "" {
 			i := data[n]
 			correct := o.Name == i.Name && o.Phone == i.Phone && o.Siblings == i.Siblings && o.Spouse == i.Spouse && o.Money == i.Money && o.BirthDay == i.BirthDay //&& cmpTags(o.Tags, i.Tags) && cmpAliases(o.Aliases, i.Aliases)


### PR DESCRIPTION
```
benchmark                                      iter    time/iter   bytes/op     allocs/op  tt.time   tt.bytes       time/alloc
BenchmarkVmihailencoMsgpackMarshal           500000   2451 ns/op   352 B/op   5 allocs/op   1.23 s   17600 KB  490.20 ns/alloc
BenchmarkVmihailencoMsgpackUnmarshal         500000   2429 ns/op   347 B/op  13 allocs/op   1.21 s   17350 KB  186.85 ns/alloc
BenchmarkJsonMarshal                         300000   4234 ns/op   584 B/op   7 allocs/op   1.27 s   17520 KB  604.86 ns/alloc
BenchmarkJsonUnmarshal                       200000   6730 ns/op   447 B/op   8 allocs/op   1.35 s    8940 KB  841.25 ns/alloc
BenchmarkBsonMarshal                         500000   2475 ns/op   504 B/op  19 allocs/op   1.24 s   25200 KB  130.26 ns/alloc
BenchmarkBsonUnmarshal                       500000   2695 ns/op   296 B/op  22 allocs/op   1.35 s   14800 KB  122.50 ns/alloc
BenchmarkVitessBsonMarshal                  1000000   1856 ns/op  1168 B/op   4 allocs/op   1.86 s  116800 KB  464.00 ns/alloc
BenchmarkVitessBsonUnmarshal                1000000   1016 ns/op   224 B/op   4 allocs/op   1.02 s   22400 KB  254.00 ns/alloc
BenchmarkGobMarshal                          100000  12004 ns/op  1689 B/op  35 allocs/op   1.20 s   16890 KB  342.97 ns/alloc
BenchmarkGobUnmarshal                         30000  55933 ns/op 17494 B/op 377 allocs/op   1.68 s   52482 KB  148.36 ns/alloc
BenchmarkXdrMarshal                          500000   3025 ns/op   519 B/op  23 allocs/op   1.51 s   25950 KB  131.52 ns/alloc
BenchmarkXdrUnmarshal                       1000000   2282 ns/op   271 B/op  12 allocs/op   2.28 s   27100 KB  190.17 ns/alloc
BenchmarkUgorjiCodecMsgpackMarshal           300000   4602 ns/op  1905 B/op  10 allocs/op   1.38 s   57150 KB  460.20 ns/alloc
BenchmarkUgorjiCodecMsgpackUnmarshal         300000   4433 ns/op  1840 B/op  14 allocs/op   1.33 s   55200 KB  316.64 ns/alloc
BenchmarkUgorjiCodecBincMarshal              300000   4811 ns/op  1938 B/op  10 allocs/op   1.44 s   58140 KB  481.10 ns/alloc
BenchmarkUgorjiCodecBincUnmarshal            300000   4688 ns/op  2000 B/op  17 allocs/op   1.41 s   60000 KB  275.76 ns/alloc
BenchmarkSerealMarshal                       300000   5602 ns/op  1360 B/op  26 allocs/op   1.68 s   40800 KB  215.46 ns/alloc
BenchmarkSerealUnmarshal                     300000   4644 ns/op   972 B/op  37 allocs/op   1.39 s   29160 KB  125.51 ns/alloc
BenchmarkBinaryMarshal                       500000   2483 ns/op   408 B/op  19 allocs/op   1.24 s   20400 KB  130.68 ns/alloc
BenchmarkBinaryUnmarshal                     500000   2487 ns/op   416 B/op  24 allocs/op   1.24 s   20800 KB  103.62 ns/alloc
BenchmarkMsgpMarshal                        3000000    456 ns/op   144 B/op   1 allocs/op   1.37 s   43200 KB  456.00 ns/alloc
BenchmarkMsgpUnmarshal                      3000000    568 ns/op   112 B/op   3 allocs/op   1.70 s   33600 KB  189.33 ns/alloc
BenchmarkGoprotobufMarshal                  1000000   1031 ns/op   312 B/op   4 allocs/op   1.03 s   31200 KB  257.75 ns/alloc
BenchmarkGoprotobufUnmarshal                1000000   1374 ns/op   432 B/op   9 allocs/op   1.37 s   43200 KB  152.67 ns/alloc
BenchmarkGogoprotobufMarshal                5000000    247 ns/op    64 B/op   1 allocs/op   1.24 s   32000 KB  247.00 ns/alloc
BenchmarkGogoprotobufUnmarshal              5000000    345 ns/op   112 B/op   3 allocs/op   1.73 s   56000 KB  115.00 ns/alloc
BenchmarkProtobufMarshal                    1000000   1501 ns/op   232 B/op   9 allocs/op   1.50 s   23200 KB  166.78 ns/alloc
BenchmarkProtobufUnmarshal                  1000000   1156 ns/op   192 B/op  10 allocs/op   1.16 s   19200 KB  115.60 ns/alloc
BenchmarkHproseMarshal                      1000000   1205 ns/op   473 B/op   8 allocs/op   1.21 s   47300 KB  150.62 ns/alloc
BenchmarkHproseUnmarshal                    1000000   1661 ns/op   319 B/op  12 allocs/op   1.66 s   31900 KB  138.42 ns/alloc
```