### PR TITLE
Adding unsafe version of gencode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,13 @@ structdef.capnp.go: structdef.capnp
 	
 gencode.schema.gen.go: gencode.schema
 	gencode go -schema=gencode.schema -package=goserbench
+	
+gencode-unsafe.schema.gen.go: gencode-unsafe.schema
+	gencode go -schema=gencode-unsafe.schema -package=goserbench -unsafe
 
 .PHONY: clean
 clean:
-	rm -f FlatBufferA.go msgp_gen.go structdef-gogo.pb.go structdef.pb.go vitess_test.go structdef.capnp.go structdef.capnp2.go gencode.schema.gen.go
+	rm -f FlatBufferA.go msgp_gen.go structdef-gogo.pb.go structdef.pb.go vitess_test.go structdef.capnp.go structdef.capnp2.go gencode.schema.gen.go gencode-unsafe.schema.gen.go
 
 .PHONY: install
 install:

--- a/gencode-unsafe.schema
+++ b/gencode-unsafe.schema
@@ -1,0 +1,8 @@
+struct GencodeUnsafeA {
+    Name     string
+    BirthDay int64
+    Phone    string
+    Siblings vint64
+    Spouse   bool
+    Money    float64
+}

--- a/gencode-unsafe.schema.gen.go
+++ b/gencode-unsafe.schema.gen.go
@@ -1,0 +1,234 @@
+package goserbench
+
+import (
+	"io"
+	"time"
+	"unsafe"
+)
+
+var (
+	_ = unsafe.Sizeof(0)
+	_ = io.ReadFull
+	_ = time.Now()
+)
+
+type GencodeUnsafeA struct {
+	Name     string
+	BirthDay int64
+	Phone    string
+	Siblings int64
+	Spouse   bool
+	Money    float64
+}
+
+func (d *GencodeUnsafeA) Size() (s uint64) {
+
+	{
+		l := uint64(len(d.Name))
+
+		{
+
+			t := l
+			for t >= 0x80 {
+				t <<= 7
+				s++
+			}
+			s++
+
+		}
+		s += l
+	}
+	{
+		l := uint64(len(d.Phone))
+
+		{
+
+			t := l
+			for t >= 0x80 {
+				t <<= 7
+				s++
+			}
+			s++
+
+		}
+		s += l
+	}
+	{
+
+		t := uint64(d.Siblings)
+		t <<= 1
+		if d.Siblings < 0 {
+			t = ^t
+		}
+		for t >= 0x80 {
+			t <<= 7
+			s++
+		}
+		s++
+
+	}
+	s += 17
+	return
+}
+func (d *GencodeUnsafeA) Marshal(buf []byte) ([]byte, error) {
+	size := d.Size()
+	{
+		if uint64(cap(buf)) >= size {
+			buf = buf[:size]
+		} else {
+			buf = make([]byte, size)
+		}
+	}
+	i := uint64(0)
+
+	{
+		l := uint64(len(d.Name))
+
+		{
+
+			t := uint64(l)
+
+			for t >= 0x80 {
+				buf[i+0] = byte(t) | 0x80
+				t >>= 7
+				i++
+			}
+			buf[i+0] = byte(t)
+			i++
+
+		}
+		copy(buf[i+0:], d.Name)
+		i += l
+	}
+	{
+
+		d.BirthDay = *(*int64)(unsafe.Pointer(&buf[i+0]))
+
+	}
+	{
+		l := uint64(len(d.Phone))
+
+		{
+
+			t := uint64(l)
+
+			for t >= 0x80 {
+				buf[i+8] = byte(t) | 0x80
+				t >>= 7
+				i++
+			}
+			buf[i+8] = byte(t)
+			i++
+
+		}
+		copy(buf[i+8:], d.Phone)
+		i += l
+	}
+	{
+
+		t := uint64(d.Siblings)
+
+		t <<= 1
+		if d.Siblings < 0 {
+			t = ^t
+		}
+
+		for t >= 0x80 {
+			buf[i+8] = byte(t) | 0x80
+			t >>= 7
+			i++
+		}
+		buf[i+8] = byte(t)
+		i++
+
+	}
+	{
+		if d.Spouse {
+			buf[i+8] = 1
+		} else {
+			buf[i+8] = 0
+		}
+	}
+	{
+
+		*(*float64)(unsafe.Pointer(&buf[i+9])) = d.Money
+
+	}
+	return buf[:i+17], nil
+}
+
+func (d *GencodeUnsafeA) Unmarshal(buf []byte) (uint64, error) {
+	i := uint64(0)
+
+	{
+		l := uint64(0)
+
+		{
+
+			bs := uint8(7)
+			t := uint64(buf[i+0] & 0x7F)
+			for buf[i+0]&0x80 == 0x80 {
+				i++
+				t |= uint64(buf[i+0]&0x7F) << bs
+				bs += 7
+			}
+			i++
+
+			l = t
+
+		}
+		d.Name = string(buf[i+0 : i+0+l])
+		i += l
+	}
+	{
+
+		d.BirthDay = *(*int64)(unsafe.Pointer(&buf[i+0]))
+
+	}
+	{
+		l := uint64(0)
+
+		{
+
+			bs := uint8(7)
+			t := uint64(buf[i+8] & 0x7F)
+			for buf[i+8]&0x80 == 0x80 {
+				i++
+				t |= uint64(buf[i+8]&0x7F) << bs
+				bs += 7
+			}
+			i++
+
+			l = t
+
+		}
+		d.Phone = string(buf[i+8 : i+8+l])
+		i += l
+	}
+	{
+
+		bs := uint8(7)
+		t := uint64(buf[i+8] & 0x7F)
+		for buf[i+8]&0x80 == 0x80 {
+			i++
+			t |= uint64(buf[i+8]&0x7F) << bs
+			bs += 7
+		}
+		i++
+
+		d.Siblings = int64(t >> 1)
+		if t&1 != 0 {
+			d.Siblings = ^d.Siblings
+		}
+
+	}
+	{
+		d.Spouse = buf[i+8] == 1
+	}
+	{
+
+		d.Money = *(*float64)(unsafe.Pointer(&buf[i+9]))
+
+	}
+	return i + 17, nil
+}

--- a/serialization_benchmarks_test.go
+++ b/serialization_benchmarks_test.go
@@ -814,7 +814,59 @@ func BenchmarkGencodeUnmarshal(b *testing.B) {
 		o := &GencodeA{}
 		_, err := o.Unmarshal(ser[n])
 		if err != nil {
-			b.Fatalf("goprotobuf failed to unmarshal: %s (%s)", err, ser[n])
+			b.Fatalf("gencode failed to unmarshal: %s (%s)", err, ser[n])
+		}
+		// Validate unmarshalled data.
+		if validate != "" {
+			i := data[n]
+			correct := o.Name == i.Name && o.Phone == i.Phone && o.Siblings == i.Siblings && o.Spouse == i.Spouse && o.Money == i.Money && o.BirthDay == i.BirthDay //&& cmpTags(o.Tags, i.Tags) && cmpAliases(o.Aliases, i.Aliases)
+			if !correct {
+				b.Fatalf("unmarshaled object differed:\n%v\n%v", i, o)
+			}
+		}
+	}
+}
+
+func generateGencodeUnsafe() []*GencodeUnsafeA {
+	a := make([]*GencodeUnsafeA, 0, 1000)
+	for i := 0; i < 1000; i++ {
+		a = append(a, &GencodeUnsafeA{
+			Name:     randString(16),
+			BirthDay: time.Now().UnixNano(),
+			Phone:    randString(10),
+			Siblings: rand.Int63n(5),
+			Spouse:   rand.Intn(2) == 1,
+			Money:    rand.Float64(),
+		})
+	}
+	return a
+}
+
+func BenchmarkGencodeUnsafeMarshal(b *testing.B) {
+	b.StopTimer()
+	data := generateGencodeUnsafe()
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		data[rand.Intn(len(data))].Marshal(nil)
+	}
+}
+
+func BenchmarkGencodeUnsafeUnmarshal(b *testing.B) {
+	b.StopTimer()
+	data := generateGencodeUnsafe()
+	ser := make([][]byte, len(data))
+	for i, d := range data {
+		ser[i], _ = d.Marshal(nil)
+	}
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		n := rand.Intn(len(ser))
+		o := &GencodeUnsafeA{}
+		_, err := o.Unmarshal(ser[n])
+		if err != nil {
+			b.Fatalf("gencode failed to unmarshal: %s (%s)", err, ser[n])
 		}
 		// Validate unmarshalled data.
 		if validate != "" {


### PR DESCRIPTION
If it's an option for CapNProto to have unsafe typing and such demo'd in a separate benchmark, I figured I'd add it for gencode.  As before, I haven't messed with the numbers, so you'll need to generate the results.