### PR TITLE
Add jsoniter to benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a test suite for benchmarking various Go serialization methods.
 
 - [encoding/gob](http://golang.org/pkg/encoding/gob/)
 - [encoding/json](http://golang.org/pkg/encoding/json/)
+- [github.com/json-iterator/go](https://github.com/json-iterator/go)
 - [github.com/alecthomas/binary](https://github.com/alecthomas/binary)
 - [github.com/davecgh/go-xdr/xdr](https://github.com/davecgh/go-xdr)
 - [github.com/Sereal/Sereal/Go/sereal](https://github.com/Sereal/Sereal)

--- a/serialization_benchmarks_test.go
+++ b/serialization_benchmarks_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	flatbuffers "github.com/google/flatbuffers/go"
 	"github.com/hprose/hprose-go"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/tinylib/msgp/msgp"
 	"github.com/ugorji/go/codec"
 	"gopkg.in/mgo.v2/bson"
@@ -205,6 +206,31 @@ func BenchmarkJsonMarshal(b *testing.B) {
 
 func BenchmarkJsonUnmarshal(b *testing.B) {
 	benchUnmarshal(b, JsonSerializer{})
+}
+
+// github.com/json-iterator/go
+
+type JsonIterSerializer struct{}
+
+func (j JsonIterSerializer) Marshal(o interface{}) []byte {
+	d, _ := jsoniter.Marshal(o)
+	return d
+}
+
+func (j JsonIterSerializer) Unmarshal(d []byte, o interface{}) error {
+	return jsoniter.Unmarshal(d, o)
+}
+
+func (j JsonIterSerializer) String() string {
+	return "jsoniter"
+}
+
+func BenchmarkJsonIterMarshal(b *testing.B) {
+	benchMarshal(b, JsonIterSerializer{})
+}
+
+func BenchmarkJsonIterUnmarshal(b *testing.B) {
+	benchUnmarshal(b, JsonIterSerializer{})
 }
 
 // github.com/mailru/easyjson


### PR DESCRIPTION
I figured I'd add this-- as I came across it on github while looking for iterative json parsers. The claim on the homepage is that it is much faster, which it seems to be ~2x faster on marshal but only ~30% faster on unmarshal.

I figured I'd submit the PR in case others want to see the numbers too

I didn't update the benchmark results on the README, as I have an X1 carbon 5th gen (so all the numbers would change).

Here is what I get:
```
BenchmarkJsonMarshal-4                   	  500000	      2959 ns/op	    1232 B/op	      10 allocs/op
BenchmarkJsonUnmarshal-4                 	  500000	      2982 ns/op	     464 B/op	       7 allocs/op
BenchmarkJsonIterMarshal-4               	 1000000	      1592 ns/op	     960 B/op	       7 allocs/op
BenchmarkJsonIterUnmarshal-4             	  500000	      2372 ns/op	     239 B/op	       6 allocs/op
```