### PR TITLE
Make goavro v1 compatible and add goavro v2 benchmark tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,60 +66,63 @@ type A struct {
 
 ## Results
 
-Results with Go 1.8 on a 2.5 GHz Intel Core i7 (MacBook Pro Retina 15-inch, Mid 2015):
+2017-09-28 Results with Go 1.9 on a 2.3 GHz Intel Core i7 (MacBook Pro Retina 15-inch, Late 2013):
 
 ```
-benchmark                                    iter              time/iter         bytes alloc        allocs
----------                                    ----              ---------         -----------        ------
-BenchmarkMsgpMarshal-8                       10000000           177 ns/op         128 B/op           1 allocs/op
-BenchmarkMsgpUnmarshal-8                      5000000           366 ns/op         112 B/op           3 allocs/op
-BenchmarkVmihailencoMsgpackMarshal-8          1000000          2052 ns/op         368 B/op           6 allocs/op
-BenchmarkVmihailencoMsgpackUnmarshal-8        1000000          2213 ns/op         384 B/op          13 allocs/op
-BenchmarkJsonMarshal-8                         500000          3275 ns/op        1232 B/op          10 allocs/op
-BenchmarkJsonUnmarshal-8                       500000          3432 ns/op         464 B/op           7 allocs/op
-BenchmarkEasyJsonMarshal-8                    1000000          1386 ns/op         784 B/op           5 allocs/op
-BenchmarkEasyJsonUnmarshal-8                  1000000          1481 ns/op         160 B/op           4 allocs/op
-BenchmarkBsonMarshal-8                        1000000          1444 ns/op         392 B/op          10 allocs/op
-BenchmarkBsonUnmarshal-8                      1000000          2246 ns/op         248 B/op          21 allocs/op
-BenchmarkGobMarshal-8                         1000000          1036 ns/op          48 B/op           2 allocs/op
-BenchmarkGobUnmarshal-8                       1000000          1016 ns/op         112 B/op           3 allocs/op
-BenchmarkXdrMarshal-8                         1000000          1715 ns/op         455 B/op          20 allocs/op
-BenchmarkXdrUnmarshal-8                       1000000          1553 ns/op         240 B/op          11 allocs/op
-BenchmarkUgorjiCodecMsgpackMarshal-8           500000          2301 ns/op        2753 B/op           8 allocs/op
-BenchmarkUgorjiCodecMsgpackUnmarshal-8         500000          2534 ns/op        3008 B/op           6 allocs/op
-BenchmarkUgorjiCodecBincMarshal-8             1000000          2290 ns/op        2785 B/op           8 allocs/op
-BenchmarkUgorjiCodecBincUnmarshal-8            500000          3022 ns/op        3168 B/op           9 allocs/op
-BenchmarkSerealMarshal-8                       500000          2884 ns/op         912 B/op          21 allocs/op
-BenchmarkSerealUnmarshal-8                     500000          3189 ns/op        1008 B/op          34 allocs/op
-BenchmarkBinaryMarshal-8                      1000000          1406 ns/op         256 B/op          16 allocs/op
-BenchmarkBinaryUnmarshal-8                    1000000          1629 ns/op         335 B/op          22 allocs/op
-BenchmarkFlatBuffersMarshal-8                 3000000           377 ns/op           0 B/op           0 allocs/op
-BenchmarkFlatBuffersUnmarshal-8               5000000           286 ns/op         112 B/op           3 allocs/op
-BenchmarkCapNProtoMarshal-8                   3000000           512 ns/op          56 B/op           2 allocs/op
-BenchmarkCapNProtoUnmarshal-8                 3000000           449 ns/op         200 B/op           6 allocs/op
-BenchmarkCapNProto2Marshal-8                  2000000           758 ns/op         244 B/op           3 allocs/op
-BenchmarkCapNProto2Unmarshal-8                2000000           966 ns/op         320 B/op           6 allocs/op
-BenchmarkHproseMarshal-8                      1000000          1117 ns/op         473 B/op           8 allocs/op
-BenchmarkHproseUnmarshal-8                    1000000          1469 ns/op         320 B/op          10 allocs/op
-BenchmarkProtobufMarshal-8                    1000000          1033 ns/op         200 B/op           7 allocs/op
-BenchmarkProtobufUnmarshal-8                  2000000           731 ns/op         192 B/op          10 allocs/op
-BenchmarkGoprotobufMarshal-8                  3000000           503 ns/op         312 B/op           4 allocs/op
-BenchmarkGoprotobufUnmarshal-8                2000000           677 ns/op         432 B/op           9 allocs/op
-BenchmarkGogoprotobufMarshal-8               10000000           154 ns/op          64 B/op           1 allocs/op
-BenchmarkGogoprotobufUnmarshal-8              5000000           244 ns/op          96 B/op           3 allocs/op
-BenchmarkColferMarshal-8                     10000000           133 ns/op          64 B/op           1 allocs/op
-BenchmarkColferUnmarshal-8                   10000000           200 ns/op         112 B/op           3 allocs/op
-BenchmarkGencodeMarshal-8                    10000000           172 ns/op          80 B/op           2 allocs/op
-BenchmarkGencodeUnmarshal-8                  10000000           201 ns/op         112 B/op           3 allocs/op
-BenchmarkGencodeUnsafeMarshal-8              20000000           112 ns/op          48 B/op           1 allocs/op
-BenchmarkGencodeUnsafeUnmarshal-8            10000000           161 ns/op          96 B/op           3 allocs/op
-BenchmarkXDR2Marshal-8                       10000000           177 ns/op          64 B/op           1 allocs/op
-BenchmarkXDR2Unmarshal-8                     10000000           170 ns/op          32 B/op           2 allocs/op
-BenchmarkGoAvroMarshal-8                       500000          2797 ns/op        1032 B/op          33 allocs/op
-BenchmarkGoAvroUnmarshal-8                     200000          6266 ns/op        3440 B/op          89 allocs/op
-
+benchmark                                   iter              time/iter         bytes alloc    allocs
+---------                                   ----              ---------         -----------    ------
+BenchmarkMsgpMarshal-8                      10000000           178 ns/op         128 B/op       1 allocs/op
+BenchmarkMsgpUnmarshal-8                     5000000           338 ns/op         112 B/op       3 allocs/op
+BenchmarkVmihailencoMsgpackMarshal-8         1000000          1864 ns/op         368 B/op       6 allocs/op
+BenchmarkVmihailencoMsgpackUnmarshal-8       1000000          1972 ns/op         383 B/op      13 allocs/op
+BenchmarkJsonMarshal-8                        500000          2980 ns/op        1223 B/op       9 allocs/op
+BenchmarkJsonUnmarshal-8                      500000          3120 ns/op         463 B/op       7 allocs/op
+BenchmarkEasyJsonMarshal-8                   1000000          1288 ns/op         784 B/op       5 allocs/op
+BenchmarkEasyJsonUnmarshal-8                 1000000          1330 ns/op         159 B/op       4 allocs/op
+BenchmarkBsonMarshal-8                       1000000          1415 ns/op         392 B/op      10 allocs/op
+BenchmarkBsonUnmarshal-8                     1000000          1996 ns/op         244 B/op      19 allocs/op
+BenchmarkGobMarshal-8                        1000000          1009 ns/op          48 B/op       2 allocs/op
+BenchmarkGobUnmarshal-8                      1000000          1032 ns/op         112 B/op       3 allocs/op
+BenchmarkXdrMarshal-8                        1000000          1716 ns/op         392 B/op      19 allocs/op
+BenchmarkXdrUnmarshal-8                      1000000          1455 ns/op         224 B/op      11 allocs/op
+BenchmarkUgorjiCodecMsgpackMarshal-8         1000000          2148 ns/op        2721 B/op       7 allocs/op
+BenchmarkUgorjiCodecMsgpackUnmarshal-8       1000000          2156 ns/op        3136 B/op       6 allocs/op
+BenchmarkUgorjiCodecBincMarshal-8            1000000          2172 ns/op        2753 B/op       7 allocs/op
+BenchmarkUgorjiCodecBincUnmarshal-8           500000          2322 ns/op        3296 B/op       9 allocs/op
+BenchmarkSerealMarshal-8                      500000          2753 ns/op         912 B/op      21 allocs/op
+BenchmarkSerealUnmarshal-8                    500000          3069 ns/op        1008 B/op      34 allocs/op
+BenchmarkBinaryMarshal-8                     1000000          1306 ns/op         246 B/op      14 allocs/op
+BenchmarkBinaryUnmarshal-8                   1000000          1497 ns/op         336 B/op      22 allocs/op
+BenchmarkFlatBuffersMarshal-8                5000000           389 ns/op           0 B/op       0 allocs/op
+BenchmarkFlatBuffersUnmarshal-8              5000000           252 ns/op         112 B/op       3 allocs/op
+BenchmarkCapNProtoMarshal-8                  3000000           521 ns/op          56 B/op       2 allocs/op
+BenchmarkCapNProtoUnmarshal-8                3000000           432 ns/op         200 B/op       6 allocs/op
+BenchmarkCapNProto2Marshal-8                 2000000           757 ns/op         244 B/op       3 allocs/op
+BenchmarkCapNProto2Unmarshal-8               2000000           937 ns/op         320 B/op       6 allocs/op
+BenchmarkHproseMarshal-8                     2000000           887 ns/op         332 B/op       8 allocs/op
+BenchmarkHproseUnmarshal-8                   1000000          1012 ns/op         319 B/op      10 allocs/op
+BenchmarkProtobufMarshal-8                   2000000           901 ns/op         200 B/op       7 allocs/op
+BenchmarkProtobufUnmarshal-8                 2000000           692 ns/op         192 B/op      10 allocs/op
+BenchmarkGoprotobufMarshal-8                 3000000           506 ns/op         312 B/op       4 allocs/op
+BenchmarkGoprotobufUnmarshal-8               2000000           691 ns/op         432 B/op       9 allocs/op
+BenchmarkGogoprotobufMarshal-8              10000000           152 ns/op          64 B/op       1 allocs/op
+BenchmarkGogoprotobufUnmarshal-8            10000000           221 ns/op          96 B/op       3 allocs/op
+BenchmarkColferMarshal-8                    10000000           137 ns/op          64 B/op       1 allocs/op
+BenchmarkColferUnmarshal-8                  10000000           183 ns/op         112 B/op       3 allocs/op
+BenchmarkGencodeMarshal-8                   10000000           166 ns/op          80 B/op       2 allocs/op
+BenchmarkGencodeUnmarshal-8                 10000000           181 ns/op         112 B/op       3 allocs/op
+BenchmarkGencodeUnsafeMarshal-8             20000000           104 ns/op          48 B/op       1 allocs/op
+BenchmarkGencodeUnsafeUnmarshal-8           10000000           144 ns/op          96 B/op       3 allocs/op
+BenchmarkXDR2Marshal-8                      10000000           168 ns/op          64 B/op       1 allocs/op
+BenchmarkXDR2Unmarshal-8                    10000000           143 ns/op          32 B/op       2 allocs/op
+BenchmarkGoAvroMarshal-8                      500000          2403 ns/op        1030 B/op      31 allocs/op
+BenchmarkGoAvroUnmarshal-8                    200000          5876 ns/op        3437 B/op      87 allocs/op
+BenchmarkGoAvro2TextMarshal-8                 500000          2797 ns/op        1326 B/op      20 allocs/op
+BenchmarkGoAvro2TextUnmarshal-8               500000          2665 ns/op         807 B/op      34 allocs/op
+BenchmarkGoAvro2BinaryMarshal-8              2000000           922 ns/op         510 B/op      11 allocs/op
+BenchmarkGoAvro2BinaryUnmarshal-8            2000000           989 ns/op         576 B/op      13 allocs/op
 PASS
-ok      github.com/alecthomas/go_serialization_benchmarks    80.910s
+ok      github.com/alecthomas/go_serialization_benchmarks   91.733s
 ```
 
 ## Issues

--- a/serialization_benchmarks_test.go
+++ b/serialization_benchmarks_test.go
@@ -939,58 +939,58 @@ func BenchmarkGencodeUnsafeUnmarshal(b *testing.B) {
 // github.com/calmh/xdr
 
 func generateXDR() []*XDRA {
-        a := make([]*XDRA, 0, 1000)
-        for i := 0; i < 1000; i++ {
-                a = append(a, &XDRA{
-                        Name:     randString(16),
-                        BirthDay: time.Now().UnixNano(),
-                        Phone:    randString(10),
-                        Siblings: rand.Int31n(5),
-                        Spouse:   rand.Intn(2) == 1,
-                        Money:    math.Float64bits(rand.Float64()),
-                })
-        }
-        return a
+	a := make([]*XDRA, 0, 1000)
+	for i := 0; i < 1000; i++ {
+		a = append(a, &XDRA{
+			Name:     randString(16),
+			BirthDay: time.Now().UnixNano(),
+			Phone:    randString(10),
+			Siblings: rand.Int31n(5),
+			Spouse:   rand.Intn(2) == 1,
+			Money:    math.Float64bits(rand.Float64()),
+		})
+	}
+	return a
 }
 
 func BenchmarkXDR2Marshal(b *testing.B) {
-        b.StopTimer()
-        data := generateXDR()
-        b.ReportAllocs()
-        b.StartTimer()
-        for i := 0; i < b.N; i++ {
-                data[rand.Intn(len(data))].MarshalXDR()
-        }
+	b.StopTimer()
+	data := generateXDR()
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		data[rand.Intn(len(data))].MarshalXDR()
+	}
 }
 
 func BenchmarkXDR2Unmarshal(b *testing.B) {
-        b.StopTimer()
-        data := generateXDR()
-        ser := make([][]byte, len(data))
-        for i, d := range data {
-                ser[i] = d.MustMarshalXDR()
-        }
-        b.ReportAllocs()
-        b.StartTimer()
-        for i := 0; i < b.N; i++ {
-                n := rand.Intn(len(ser))
-                o := XDRA{}
-                err := o.UnmarshalXDR(ser[n])
-                if err != nil {
-                        b.Fatalf("xdr failed to unmarshal: %s (%s)", err, ser[n])
-                }
-                // Validate unmarshalled data.
-                if validate != "" {
-                        i := data[n]
-                        correct := o.Name == i.Name && o.Phone == i.Phone && o.Siblings == i.Siblings && o.Spouse == i.Spouse && o.Money == i.Money && o.BirthDay == i.BirthDay
-                        if !correct {
-                                b.Fatalf("unmarshaled object differed:\n%v\n%v", i, o)
-                        }
-                }
-        }
+	b.StopTimer()
+	data := generateXDR()
+	ser := make([][]byte, len(data))
+	for i, d := range data {
+		ser[i] = d.MustMarshalXDR()
+	}
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		n := rand.Intn(len(ser))
+		o := XDRA{}
+		err := o.UnmarshalXDR(ser[n])
+		if err != nil {
+			b.Fatalf("xdr failed to unmarshal: %s (%s)", err, ser[n])
+		}
+		// Validate unmarshalled data.
+		if validate != "" {
+			i := data[n]
+			correct := o.Name == i.Name && o.Phone == i.Phone && o.Siblings == i.Siblings && o.Spouse == i.Spouse && o.Money == i.Money && o.BirthDay == i.BirthDay
+			if !correct {
+				b.Fatalf("unmarshaled object differed:\n%v\n%v", i, o)
+			}
+		}
+	}
 }
 
-// github.com/linkedin/goavro
+// gopkg.in/linkedin/goavro.v1
 
 func BenchmarkGoAvroMarshal(b *testing.B) {
 	benchMarshal(b, NewAvroA())
@@ -1000,3 +1000,20 @@ func BenchmarkGoAvroUnmarshal(b *testing.B) {
 	benchUnmarshal(b, NewAvroA())
 }
 
+// github.com/linkedin/goavro
+
+func BenchmarkGoAvro2TextMarshal(b *testing.B) {
+	benchMarshal(b, NewAvro2Txt())
+}
+
+func BenchmarkGoAvro2TextUnmarshal(b *testing.B) {
+	benchUnmarshal(b, NewAvro2Txt())
+}
+
+func BenchmarkGoAvro2BinaryMarshal(b *testing.B) {
+	benchMarshal(b, NewAvro2Bin())
+}
+
+func BenchmarkGoAvro2BinaryUnmarshal(b *testing.B) {
+	benchUnmarshal(b, NewAvro2Bin())
+}

--- a/structdef_avro.go
+++ b/structdef_avro.go
@@ -3,13 +3,23 @@ package goserbench
 import (
 	"bytes"
 	"fmt"
-	"github.com/linkedin/goavro"
 	"time"
+
+	goavro2 "github.com/linkedin/goavro"
+	goavro "gopkg.in/linkedin/goavro.v1"
 )
 
 type AvroA struct {
 	record *goavro.Record
 	codec  goavro.Codec
+}
+
+type Avro2Txt struct {
+	codec *goavro2.Codec
+}
+
+type Avro2Bin struct {
+	codec *goavro2.Codec
 }
 
 var (
@@ -105,4 +115,80 @@ func (a *AvroA) Unmarshal(d []byte, o interface{}) error {
 
 func (a *AvroA) String() string {
 	return "GoAvro"
+}
+
+func avroMarshal(o interface{}, marshalFunc func([]byte, interface{}) ([]byte, error)) []byte {
+	object := o.(*A)
+	b, err := marshalFunc(nil, map[string]interface{}{
+		"name":     object.Name,
+		"birthday": int64(object.BirthDay.UnixNano()),
+		"phone":    object.Phone,
+		"siblings": int32(object.Siblings),
+		"spouse":   object.Spouse,
+		"money":    object.Money,
+	})
+	if err != nil {
+		fmt.Printf("Avro2 encoding error: %v\n", err)
+		return []byte("")
+	}
+	return b
+}
+
+func avroUnmarshal(d []byte, o interface{}, unmarshalFunc func([]byte) (interface{}, []byte, error)) error {
+	object := o.(*A)
+	r, _, err := unmarshalFunc(d)
+	if err != nil {
+		fmt.Printf("Avro2 decoding error: %v\n", err)
+		return err
+	}
+	m := r.(map[string]interface{})
+	object.Name = m["name"].(string)
+	object.BirthDay = time.Unix(0, m["birthday"].(int64))
+	object.Phone = m["phone"].(string)
+	object.Siblings = int(m["siblings"].(int32))
+	object.Spouse = m["spouse"].(bool)
+	object.Money = m["money"].(float64)
+	return nil
+}
+
+func NewAvro2Txt() *Avro2Txt {
+	codec, err := goavro2.NewCodec(avroSchemaJSON)
+	if err != nil {
+		fmt.Printf("Avro2Txt codec initialization error: %v\n", err)
+		return nil
+	}
+	return &Avro2Txt{codec: codec}
+}
+
+func (a *Avro2Txt) Marshal(o interface{}) []byte {
+	return avroMarshal(o, a.codec.TextualFromNative)
+}
+
+func (a *Avro2Txt) Unmarshal(d []byte, o interface{}) error {
+	return avroUnmarshal(d, o, a.codec.NativeFromTextual)
+}
+
+func (a *Avro2Txt) String() string {
+	return "GoAvro2Text"
+}
+
+func NewAvro2Bin() *Avro2Bin {
+	codec, err := goavro2.NewCodec(avroSchemaJSON)
+	if err != nil {
+		fmt.Printf("Avro2Bin codec initialization error: %v\n", err)
+		return nil
+	}
+	return &Avro2Bin{codec: codec}
+}
+
+func (a *Avro2Bin) Marshal(o interface{}) []byte {
+	return avroMarshal(o, a.codec.BinaryFromNative)
+}
+
+func (a *Avro2Bin) Unmarshal(d []byte, o interface{}) error {
+	return avroUnmarshal(d, o, a.codec.NativeFromBinary)
+}
+
+func (a *Avro2Bin) String() string {
+	return "GoAvro2Binary"
 }


### PR DESCRIPTION
Fixes #64 

Should probably regenerate the report on golang 1.9 with the latest packages. I can do that as well if you feel comfortable or you can run it after merging @alecthomas 