### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/structdef.capnp2.go
+++ b/structdef.capnp2.go
@@ -141,7 +141,7 @@ func (s Capnp2A) SetMoney(v float64) {
 // Capnp2A_List is a list of Capnp2A.
 type Capnp2A_List struct{ capnp.List }
 
-// NewCapnp2A creates a new list of Capnp2A.
+// NewCapnp2A_List creates a new list of Capnp2A.
 func NewCapnp2A_List(s *capnp.Segment, sz int32) (Capnp2A_List, error) {
 	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 24, PointerCount: 2}, sz)
 	if err != nil {


### PR DESCRIPTION
Hi, I've changed these public function comments to comply with [this standard](https://golang.org/doc/effective_go.html#commentary) in Effective Go. It's admittedly a small fix but I hope it helps!