### PR TITLE
Report serial size (and errors)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/alecthomas/go_serialization_benchmarks
 
-go 1.12
+go 1.13


### PR DESCRIPTION
The upcomming Go version 1.13 provides benchmark metrics, which we can use to report the serial size for each format.

I need some help with the awk(1) magic in stats.sh.