### PR TITLE
Easyjson test should not interfere with json test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ msgp_gen.go: structdef.go
 	go run github.com/tinylib/msgp -o msgp_gen.go -file structdef.go -io=false -tests=false
 
 structdef_easyjson.go: structdef.go
-	go run github.com/mailru/easyjson/easyjson -all structdef.go
+	go run github.com/mailru/easyjson/easyjson -no_std_marshalers -all structdef.go
 
 structdef-gogo.pb.go: structdef-gogo.proto
 	protoc --gogofaster_out=. -I. -I${GOPATH}/src  -I${GOPATH}/src/github.com/gogo/protobuf/protobuf structdef-gogo.proto

--- a/serialization_benchmarks_test.go
+++ b/serialization_benchmarks_test.go
@@ -22,6 +22,7 @@ import (
 	hprose2 "github.com/hprose/hprose-golang/io"
 	ikea "github.com/ikkerens/ikeapack"
 	jsoniter "github.com/json-iterator/go"
+	easyjson "github.com/mailru/easyjson"
 	"github.com/niubaoshu/gotiny"
 	ssz "github.com/prysmaticlabs/go-ssz"
 	shamaton "github.com/shamaton/msgpack"
@@ -339,11 +340,11 @@ func BenchmarkJsonIterUnmarshal(b *testing.B) {
 type EasyJSONSerializer struct{}
 
 func (m EasyJSONSerializer) Marshal(o interface{}) ([]byte, error) {
-	return o.(*A).MarshalJSON()
+	return easyjson.Marshal(o.(easyjson.Marshaler))
 }
 
 func (m EasyJSONSerializer) Unmarshal(d []byte, o interface{}) error {
-	return o.(*A).UnmarshalJSON(d)
+	return easyjson.Unmarshal(d, o.(*A))
 }
 
 func BenchmarkEasyJsonMarshal(b *testing.B) {

--- a/structdef_easyjson.go
+++ b/structdef_easyjson.go
@@ -105,23 +105,9 @@ func easyjsonB0f55b16EncodeGithubComAlecthomasGoSerializationBenchmarks(out *jwr
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v NoTimeNoStringNoFloatA) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonB0f55b16EncodeGithubComAlecthomasGoSerializationBenchmarks(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v NoTimeNoStringNoFloatA) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonB0f55b16EncodeGithubComAlecthomasGoSerializationBenchmarks(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *NoTimeNoStringNoFloatA) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonB0f55b16DecodeGithubComAlecthomasGoSerializationBenchmarks(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -206,23 +192,9 @@ func easyjsonB0f55b16EncodeGithubComAlecthomasGoSerializationBenchmarks1(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v NoTimeA) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonB0f55b16EncodeGithubComAlecthomasGoSerializationBenchmarks1(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v NoTimeA) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonB0f55b16EncodeGithubComAlecthomasGoSerializationBenchmarks1(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *NoTimeA) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonB0f55b16DecodeGithubComAlecthomasGoSerializationBenchmarks1(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -309,23 +281,9 @@ func easyjsonB0f55b16EncodeGithubComAlecthomasGoSerializationBenchmarks2(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v A) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonB0f55b16EncodeGithubComAlecthomasGoSerializationBenchmarks2(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v A) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonB0f55b16EncodeGithubComAlecthomasGoSerializationBenchmarks2(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *A) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonB0f55b16DecodeGithubComAlecthomasGoSerializationBenchmarks2(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface


### PR DESCRIPTION
The generated easyjson code included standard encoding/json Marshaler and Unmarshaler interfaces. These will have been picked up and called by the encoding/json code and throw off the result for encoding/json (encoding/json test will have been using the easyjson code).

It's better if we generate only the easyjson-specific interfaces. The easyjson doc claims these are better.