### PR TITLE
fix unused import error in benchmarks test

### DIFF
--- a/serialization_benchmarks_test.go
+++ b/serialization_benchmarks_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Sereal/Sereal/Go/sereal"
 	"github.com/alecthomas/binary"
 	"github.com/davecgh/go-xdr/xdr"
-	"github.com/deneonet/benc/bpre"
 	capn "github.com/glycerine/go-capnproto"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"


### PR DESCRIPTION
bpre use was removed in a previous commit, but the import lingered. This commit removes the unused import, allowing tests to run again.