### PR TITLE
Switch to serializer tests

### DIFF
--- a/gencode.go
+++ b/gencode.go
@@ -1,0 +1,79 @@
+package goserbench
+
+import "time"
+
+type GencodeSerializer struct {
+	buf []byte
+	a   GencodeA
+}
+
+func (s *GencodeSerializer) Marshal(o interface{}) ([]byte, error) {
+	v := o.(*A)
+	a := &s.a
+	a.Name = v.Name
+	a.BirthDay = v.BirthDay
+	a.Phone = v.Phone
+	a.Siblings = int32(v.Siblings)
+	a.Spouse = v.Spouse
+	a.Money = v.Money
+	return a.Marshal(s.buf)
+}
+
+func (s *GencodeSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
+	a := &s.a
+	_, err = a.Unmarshal(bs)
+	if err != nil {
+		return
+	}
+
+	v := o.(*A)
+	v.Name = a.Name
+	v.BirthDay = a.BirthDay
+	v.Phone = a.Phone
+	v.Siblings = int(a.Siblings)
+	v.Spouse = a.Spouse
+	v.Money = a.Money
+	return
+}
+
+func newGencodeSerializer() *GencodeSerializer {
+	return &GencodeSerializer{buf: make([]byte, 0, 1024)}
+}
+
+type GencodeUnsafeSerializer struct {
+	buf []byte
+	a   GencodeUnsafeA
+}
+
+func (s *GencodeUnsafeSerializer) Marshal(o interface{}) ([]byte, error) {
+	v := o.(*A)
+	a := &s.a
+	a.Name = v.Name
+	a.BirthDay = v.BirthDay.UnixNano()
+	a.Phone = v.Phone
+	a.Siblings = int32(v.Siblings)
+	a.Spouse = v.Spouse
+	a.Money = v.Money
+	return a.Marshal(s.buf)
+}
+
+func (s *GencodeUnsafeSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
+	a := &s.a
+	_, err = a.Unmarshal(bs)
+	if err != nil {
+		return
+	}
+
+	v := o.(*A)
+	v.Name = a.Name
+	v.BirthDay = time.Unix(0, a.BirthDay)
+	v.Phone = a.Phone
+	v.Siblings = int(a.Siblings)
+	v.Spouse = a.Spouse
+	v.Money = a.Money
+	return
+}
+
+func newGencodeUnsafeSerializer() *GencodeUnsafeSerializer {
+	return &GencodeUnsafeSerializer{buf: make([]byte, 0, 1024)}
+}

--- a/mus.go
+++ b/mus.go
@@ -1,36 +1,47 @@
 package goserbench
 
 import (
+	"time"
+
 	"github.com/mus-format/mus-go/ord"
 	"github.com/mus-format/mus-go/raw"
 	"github.com/mus-format/mus-go/unsafe"
 	"github.com/mus-format/mus-go/varint"
 )
 
-func MarshalMUS(v MUSA) (buf []byte) {
+type MUSSerializer struct{}
+
+func (s MUSSerializer) Marshal(o interface{}) ([]byte, error) {
+	v := o.(*A)
 	n := ord.SizeString(v.Name)
-	n += raw.SizeInt64(v.BirthDay)
+	n += raw.SizeInt64(v.BirthDay.UnixNano())
 	n += ord.SizeString(v.Phone)
-	n += varint.SizeInt32(v.Siblings)
+	n += varint.SizeInt32(int32(v.Siblings))
 	n += ord.SizeBool(v.Spouse)
 	n += raw.SizeFloat64(v.Money)
-	buf = make([]byte, n)
+	buf := make([]byte, n)
 	n = ord.MarshalString(v.Name, buf)
-	n += raw.MarshalInt64(v.BirthDay, buf[n:])
+	n += raw.MarshalInt64(v.BirthDay.UnixNano(), buf[n:])
 	n += ord.MarshalString(v.Phone, buf[n:])
-	n += varint.MarshalInt32(v.Siblings, buf[n:])
+	n += varint.MarshalInt32(int32(v.Siblings), buf[n:])
 	n += ord.MarshalBool(v.Spouse, buf[n:])
 	raw.MarshalFloat64(v.Money, buf[n:])
-	return
+	return buf, nil
 }
 
-func UnmarshalMUS(bs []byte) (v MUSA, n int, err error) {
+func (s MUSSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
+	v := o.(*A)
+
+	var n int
+
 	v.Name, n, err = ord.UnmarshalString(bs)
 	if err != nil {
 		return
 	}
 	var n1 int
-	v.BirthDay, n1, err = raw.UnmarshalInt64(bs[n:])
+	var bdayNano int64
+	bdayNano, n1, err = raw.UnmarshalInt64(bs[n:])
+	v.BirthDay = time.Unix(0, bdayNano)
 	n += n1
 	if err != nil {
 		return
@@ -40,7 +51,9 @@ func UnmarshalMUS(bs []byte) (v MUSA, n int, err error) {
 	if err != nil {
 		return
 	}
-	v.Siblings, n1, err = varint.UnmarshalInt32(bs[n:])
+	var sibInt32 int32
+	sibInt32, n1, err = varint.UnmarshalInt32(bs[n:])
+	v.Siblings = int(sibInt32)
 	n += n1
 	if err != nil {
 		return
@@ -55,30 +68,38 @@ func UnmarshalMUS(bs []byte) (v MUSA, n int, err error) {
 	return
 }
 
-func MarshalMUSUnsafe(v MUSA) (buf []byte) {
+type MUSUnsafeSerializer struct{}
+
+func (s MUSUnsafeSerializer) Marshal(o interface{}) ([]byte, error) {
+	v := o.(*A)
 	n := unsafe.SizeString(v.Name)
-	n += unsafe.SizeInt64(v.BirthDay)
+	n += unsafe.SizeInt64(v.BirthDay.UnixNano())
 	n += unsafe.SizeString(v.Phone)
-	n += unsafe.SizeInt32(v.Siblings)
+	n += unsafe.SizeInt32(int32(v.Siblings))
 	n += unsafe.SizeBool(v.Spouse)
 	n += unsafe.SizeFloat64(v.Money)
-	buf = make([]byte, n)
+	buf := make([]byte, n)
 	n = unsafe.MarshalString(v.Name, buf)
-	n += unsafe.MarshalInt64(v.BirthDay, buf[n:])
+	n += unsafe.MarshalInt64(v.BirthDay.UnixNano(), buf[n:])
 	n += unsafe.MarshalString(v.Phone, buf[n:])
-	n += unsafe.MarshalInt32(v.Siblings, buf[n:])
+	n += unsafe.MarshalInt32(int32(v.Siblings), buf[n:])
 	n += unsafe.MarshalBool(v.Spouse, buf[n:])
 	unsafe.MarshalFloat64(v.Money, buf[n:])
-	return
+	return buf, nil
 }
 
-func UnmarshalMUSUnsafe(bs []byte) (v MUSA, n int, err error) {
+func (s MUSUnsafeSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
+	var n int
+	v := o.(*A)
+
 	v.Name, n, err = unsafe.UnmarshalString(bs)
 	if err != nil {
 		return
 	}
 	var n1 int
-	v.BirthDay, n1, err = unsafe.UnmarshalInt64(bs[n:])
+	var bdayNano int64
+	bdayNano, n1, err = unsafe.UnmarshalInt64(bs[n:])
+	v.BirthDay = time.Unix(0, bdayNano)
 	n += n1
 	if err != nil {
 		return
@@ -88,7 +109,9 @@ func UnmarshalMUSUnsafe(bs []byte) (v MUSA, n int, err error) {
 	if err != nil {
 		return
 	}
-	v.Siblings, n1, err = unsafe.UnmarshalInt32(bs[n:])
+	var sibInt32 int32
+	sibInt32, n1, err = unsafe.UnmarshalInt32(bs[n:])
+	v.Siblings = int(sibInt32)
 	n += n1
 	if err != nil {
 		return

--- a/serialization_benchmarks_test.go
+++ b/serialization_benchmarks_test.go
@@ -1910,109 +1910,20 @@ func Benchmark_BENCUnsafe_Unmarshal(b *testing.B) {
 
 // github.com/mus-format/mus-go
 
-func generateMUS() []MUSA {
-	a := make([]MUSA, 0, 1000)
-	for i := 0; i < 1000; i++ {
-		a = append(a, MUSA{
-			Name:     randString(16),
-			BirthDay: time.Now().UnixNano(),
-			Phone:    randString(10),
-			Siblings: rand.Int31n(5),
-			Spouse:   rand.Intn(2) == 1,
-			Money:    rand.Float64(),
-		})
-	}
-	return a
-}
-
 func Benchmark_MUS_Marshal(b *testing.B) {
-	data := generateMUS()
-	b.ReportAllocs()
-	b.ResetTimer()
-	var serialSize int
-	var buf []byte
-	var o MUSA
-	for i := 0; i < b.N; i++ {
-		o = data[rand.Intn(len(data))]
-		buf = MarshalMUS(o)
-		serialSize += len(buf)
-	}
-	b.ReportMetric(float64(serialSize)/float64(b.N), "B/serial")
+	benchMarshal(b, MUSSerializer{})
 }
 
 func Benchmark_MUS_Unmarshal(b *testing.B) {
-	b.StopTimer()
-	data := generateMUS()
-	ser := make([][]byte, len(data))
-	var serialSize int
-	for i, d := range data {
-		ser[i] = MarshalMUS(d)
-		serialSize += len(ser[i])
-	}
-	b.ReportMetric(float64(serialSize)/float64(len(data)), "B/serial")
-	b.ReportAllocs()
-	b.StartTimer()
-
-	for i := 0; i < b.N; i++ {
-		n := rand.Intn(len(ser))
-		o, _, err := UnmarshalMUS(ser[n])
-		if err != nil {
-			b.Fatalf("mus failed to unmarshal: %s (%s)", err, ser[n])
-		}
-		// Validate unmarshalled data.
-		if validate != "" {
-			i := data[n]
-			correct := o.Name == i.Name && o.Phone == i.Phone && o.Siblings == i.Siblings && o.Spouse == i.Spouse && o.Money == i.Money && o.BirthDay == i.BirthDay //&& cmpTags(o.Tags, i.Tags) && cmpAliases(o.Aliases, i.Aliases)
-			if !correct {
-				b.Fatalf("unmarshaled object differed:\n%v\n%v", i, o)
-			}
-		}
-	}
+	benchUnmarshal(b, MUSSerializer{})
 }
 
 func Benchmark_MUSUnsafe_Marshal(b *testing.B) {
-	data := generateMUS()
-	b.ReportAllocs()
-	b.ResetTimer()
-	var serialSize int
-	var buf []byte
-	var o MUSA
-	for i := 0; i < b.N; i++ {
-		o = data[rand.Intn(len(data))]
-		buf = MarshalMUSUnsafe(o)
-		serialSize += len(buf)
-	}
-	b.ReportMetric(float64(serialSize)/float64(b.N), "B/serial")
+	benchMarshal(b, MUSUnsafeSerializer{})
 }
 
 func Benchmark_MUSUnsafe_Unmarshal(b *testing.B) {
-	b.StopTimer()
-	data := generateMUS()
-	ser := make([][]byte, len(data))
-	var serialSize int
-	for i, d := range data {
-		ser[i] = MarshalMUSUnsafe(d)
-		serialSize += len(ser[i])
-	}
-	b.ReportMetric(float64(serialSize)/float64(len(data)), "B/serial")
-	b.ReportAllocs()
-	b.StartTimer()
-
-	for i := 0; i < b.N; i++ {
-		n := rand.Intn(len(ser))
-		o, _, err := UnmarshalMUSUnsafe(ser[n])
-		if err != nil {
-			b.Fatalf("mus failed to unmarshal: %s (%s)", err, ser[n])
-		}
-		// Validate unmarshalled data.
-		if validate != "" {
-			i := data[n]
-			correct := o.Name == i.Name && o.Phone == i.Phone && o.Siblings == i.Siblings && o.Spouse == i.Spouse && o.Money == i.Money && o.BirthDay == i.BirthDay //&& cmpTags(o.Tags, i.Tags) && cmpAliases(o.Aliases, i.Aliases)
-			if !correct {
-				b.Fatalf("unmarshaled object differed:\n%v\n%v", i, o)
-			}
-		}
-	}
+	benchUnmarshal(b, MUSUnsafeSerializer{})
 }
 
 func Benchmark_Baseline_Marshal(b *testing.B) {

--- a/serialization_benchmarks_test.go
+++ b/serialization_benchmarks_test.go
@@ -1126,134 +1126,20 @@ func Benchmark_Colfer_Unmarshal(b *testing.B) {
 
 // github.com/andyleap/gencode
 
-func generateGencode() []*GencodeA {
-	a := make([]*GencodeA, 0, 1000)
-	for i := 0; i < 1000; i++ {
-		a = append(a, &GencodeA{
-			Name:     randString(16),
-			BirthDay: time.Now(),
-			Phone:    randString(10),
-			Siblings: rand.Int31n(5),
-			Spouse:   rand.Intn(2) == 1,
-			Money:    rand.Float64(),
-		})
-	}
-	return a
-}
-
 func Benchmark_Gencode_Marshal(b *testing.B) {
-	data := generateGencode()
-	b.ReportAllocs()
-	b.ResetTimer()
-	var serialSize int
-	for i := 0; i < b.N; i++ {
-		bytes, err := data[rand.Intn(len(data))].Marshal(nil)
-		if err != nil {
-			b.Fatal(err)
-		}
-		serialSize += len(bytes)
-	}
-	b.ReportMetric(float64(serialSize)/float64(b.N), "B/serial")
+	benchMarshal(b, newGencodeSerializer())
 }
 
 func Benchmark_Gencode_Unmarshal(b *testing.B) {
-	b.StopTimer()
-	data := generateGencode()
-	ser := make([][]byte, len(data))
-	var serialSize int
-	for i, d := range data {
-		var err error
-		ser[i], err = d.Marshal(nil)
-		if err != nil {
-			b.Fatal(err)
-		}
-		serialSize += len(ser[i])
-	}
-	b.ReportMetric(float64(serialSize)/float64(len(data)), "B/serial")
-	b.ReportAllocs()
-	b.StartTimer()
-
-	for i := 0; i < b.N; i++ {
-		n := rand.Intn(len(ser))
-		o := &GencodeA{}
-		_, err := o.Unmarshal(ser[n])
-		if err != nil {
-			b.Fatalf("gencode failed to unmarshal: %s (%s)", err, ser[n])
-		}
-		// Validate unmarshalled data.
-		if validate != "" {
-			i := data[n]
-			correct := o.Name == i.Name && o.Phone == i.Phone && o.Siblings == i.Siblings && o.Spouse == i.Spouse && o.Money == i.Money && o.BirthDay.Equal(i.BirthDay) //&& cmpTags(o.Tags, i.Tags) && cmpAliases(o.Aliases, i.Aliases)
-			if !correct {
-				b.Fatalf("unmarshaled object differed:\n%v\n%v", i, o)
-			}
-		}
-	}
-}
-
-func generateGencodeUnsafe() []*GencodeUnsafeA {
-	a := make([]*GencodeUnsafeA, 0, 1000)
-	for i := 0; i < 1000; i++ {
-		a = append(a, &GencodeUnsafeA{
-			Name:     randString(16),
-			BirthDay: time.Now().UnixNano(),
-			Phone:    randString(10),
-			Siblings: rand.Int31n(5),
-			Spouse:   rand.Intn(2) == 1,
-			Money:    rand.Float64(),
-		})
-	}
-	return a
+	benchUnmarshal(b, newGencodeSerializer())
 }
 
 func Benchmark_GencodeUnsafe_Marshal(b *testing.B) {
-	data := generateGencodeUnsafe()
-	b.ReportAllocs()
-	b.ResetTimer()
-	var serialSize int
-	for i := 0; i < b.N; i++ {
-		bytes, err := data[rand.Intn(len(data))].Marshal(nil)
-		if err != nil {
-			b.Fatal(err)
-		}
-		serialSize += len(bytes)
-	}
-	b.ReportMetric(float64(serialSize)/float64(b.N), "B/serial")
+	benchMarshal(b, newGencodeUnsafeSerializer())
 }
 
 func Benchmark_GencodeUnsafe_Unmarshal(b *testing.B) {
-	b.StopTimer()
-	data := generateGencodeUnsafe()
-	ser := make([][]byte, len(data))
-	var serialSize int
-	for i, d := range data {
-		var err error
-		ser[i], err = d.Marshal(nil)
-		if err != nil {
-			b.Fatal(err)
-		}
-		serialSize += len(ser[i])
-	}
-	b.ReportMetric(float64(serialSize)/float64(len(data)), "B/serial")
-	b.ReportAllocs()
-	b.StartTimer()
-
-	for i := 0; i < b.N; i++ {
-		n := rand.Intn(len(ser))
-		o := &GencodeUnsafeA{}
-		_, err := o.Unmarshal(ser[n])
-		if err != nil {
-			b.Fatalf("gencode failed to unmarshal: %s (%s)", err, ser[n])
-		}
-		// Validate unmarshalled data.
-		if validate != "" {
-			i := data[n]
-			correct := o.Name == i.Name && o.Phone == i.Phone && o.Siblings == i.Siblings && o.Spouse == i.Spouse && o.Money == i.Money && o.BirthDay == i.BirthDay //&& cmpTags(o.Tags, i.Tags) && cmpAliases(o.Aliases, i.Aliases)
-			if !correct {
-				b.Fatalf("unmarshaled object differed:\n%v\n%v", i, o)
-			}
-		}
-	}
+	benchUnmarshal(b, newGencodeUnsafeSerializer())
 }
 
 // github.com/calmh/xdr


### PR DESCRIPTION
This switches various bencharmarks to use the serializer interface and benchmark functions.

The following benchmarks have been switched to use the serializer interface:

- MUS
- MUSUnsafe
- Gencode
- GencodeUnsafe