### PR TITLE
Remove allocation from unmarshal benchmark

### DIFF
--- a/serialization_benchmarks_test.go
+++ b/serialization_benchmarks_test.go
@@ -128,13 +128,15 @@ func benchUnmarshal(b *testing.B, s Serializer) {
 		serialSize += copy(t, o)
 		ser[i] = t
 	}
+	o := &A{}
+
 	b.ReportMetric(float64(serialSize)/float64(len(data)), "B/serial")
 	b.ReportAllocs()
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
 		n := rand.Intn(len(ser))
-		o := &A{}
+		*o = A{}
 		err := s.Unmarshal(ser[n], o)
 		if err != nil {
 			b.Fatalf("unmarshal error %s for %#x / %q", err, ser[n], ser[n])


### PR DESCRIPTION
This removes one allocation from all benchmarks that are run with the standard benchUnmarshal() function.

The allocation was for the target of the unmarshal. This is replaced with a single object used throughout the test and cleared before each test iteration.