### PR TITLE
goserbench: Initial Version

### DIFF
--- a/adapter_interface.go
+++ b/adapter_interface.go
@@ -1,0 +1,9 @@
+package goserbench
+
+import (
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
+)
+
+// These are only used during the refactoring and will be removed in the future.
+
+type Serializer = goserbench.Serializer

--- a/baseline.go
+++ b/baseline.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"time"
 	"unsafe"
+
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 )
 
 // BaselineSerializer is a baseline test for marshalling/unmarshalling. It
@@ -36,7 +38,7 @@ func getBool(b []byte) bool {
 }
 
 func (b *BaselineSerializer) Marshal(o interface{}) ([]byte, error) {
-	a := o.(*A)
+	a := o.(*goserbench.SmallStruct)
 	buf := b.b[:0]
 	buf = binary.LittleEndian.AppendUint64(buf, uint64(a.BirthDay.UnixNano()))
 	buf = binary.LittleEndian.AppendUint64(buf, math.Float64bits(a.Money))
@@ -48,7 +50,7 @@ func (b *BaselineSerializer) Marshal(o interface{}) ([]byte, error) {
 }
 
 func (b *BaselineSerializer) Unmarshal(d []byte, o interface{}) error {
-	a := o.(*A)
+	a := o.(*goserbench.SmallStruct)
 	a.BirthDay = time.Unix(0, int64(binary.LittleEndian.Uint64(d[:8])))
 	a.Money = math.Float64frombits(binary.LittleEndian.Uint64(d[8:16]))
 	a.Siblings = int(binary.LittleEndian.Uint32(d[16:20]))

--- a/bebop_200sc.go
+++ b/bebop_200sc.go
@@ -1,6 +1,10 @@
 package goserbench
 
-import "time"
+import (
+	"time"
+
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
+)
 
 type Bebop200ScSerializer struct {
 	a   BebopBuf200sc
@@ -8,7 +12,7 @@ type Bebop200ScSerializer struct {
 }
 
 func (s *Bebop200ScSerializer) Marshal(o interface{}) (buf []byte, err error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	a := &s.a
 	a.Name = v.Name
 	a.BirthDay = v.BirthDay
@@ -27,7 +31,7 @@ func (s *Bebop200ScSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
 		return
 	}
 
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	v.Name = a.Name
 	v.BirthDay = a.BirthDay
 	v.Phone = a.Phone

--- a/bebop_wellquite.go
+++ b/bebop_wellquite.go
@@ -1,6 +1,10 @@
 package goserbench
 
-import "time"
+import (
+	"time"
+
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
+)
 
 type BebopWellquiteSerializer struct {
 	a   BebopBufWellquite
@@ -8,7 +12,7 @@ type BebopWellquiteSerializer struct {
 }
 
 func (s *BebopWellquiteSerializer) Marshal(o interface{}) (buf []byte, err error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	a := &s.a
 	a.Name = v.Name
 	a.BirthDay = v.BirthDay
@@ -26,7 +30,7 @@ func (s *BebopWellquiteSerializer) Unmarshal(bs []byte, o interface{}) (err erro
 		return
 	}
 
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	v.Name = a.Name
 	v.BirthDay = a.BirthDay
 	v.Phone = a.Phone

--- a/benc.go
+++ b/benc.go
@@ -3,6 +3,7 @@ package goserbench
 import (
 	"time"
 
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 	bstd "github.com/deneonet/benc"
 	"github.com/deneonet/benc/bunsafe"
 )
@@ -10,7 +11,7 @@ import (
 type BENCSerializer struct{}
 
 func (s BENCSerializer) Marshal(o interface{}) (buf []byte, err error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	n := bstd.SizeString(v.Name)
 	n += bstd.SizeInt64()
 	n += bstd.SizeString(v.Phone)
@@ -29,7 +30,7 @@ func (s BENCSerializer) Marshal(o interface{}) (buf []byte, err error) {
 }
 
 func (s BENCSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	var n int
 	n, v.Name, err = bstd.UnmarshalString(0, bs)
 	if err != nil {
@@ -67,7 +68,7 @@ func NewBENCSerializer() Serializer {
 type BENCUnsafeSerializer struct{}
 
 func (s BENCUnsafeSerializer) Marshal(o interface{}) (buf []byte, err error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	n := bstd.SizeString(v.Name)
 	n += bstd.SizeInt64()
 	n += bstd.SizeString(v.Phone)
@@ -87,7 +88,7 @@ func (s BENCUnsafeSerializer) Marshal(o interface{}) (buf []byte, err error) {
 
 func (s BENCUnsafeSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
 	var n int
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	n, v.Name, err = bunsafe.UnmarshalString(0, bs)
 	if err != nil {
 		return

--- a/capnproto.go
+++ b/capnproto.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"time"
 
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 	capn "github.com/glycerine/go-capnproto"
 )
 
 type CapNProtoSerializer struct{}
 
 func (x CapNProtoSerializer) Marshal(o interface{}) ([]byte, error) {
-	a := o.(*A)
+	a := o.(*goserbench.SmallStruct)
 	seg := capn.NewBuffer(nil)
 	c := NewRootCapnpA(seg)
 	c.SetName(a.Name)
@@ -25,7 +26,7 @@ func (x CapNProtoSerializer) Marshal(o interface{}) ([]byte, error) {
 }
 
 func (x CapNProtoSerializer) Unmarshal(d []byte, i interface{}) error {
-	a := i.(*A)
+	a := i.(*goserbench.SmallStruct)
 	s, _, err := capn.ReadFromMemoryZeroCopy(d)
 	if err != nil {
 		return err

--- a/colfer.go
+++ b/colfer.go
@@ -1,5 +1,7 @@
 package goserbench
 
+import "github.com/alecthomas/go_serialization_benchmarks/goserbench"
+
 type ColferSerializer struct {
 	a ColferA
 }
@@ -9,7 +11,7 @@ func (s *ColferSerializer) ForceUTC() bool {
 }
 
 func (s *ColferSerializer) Marshal(o interface{}) (buf []byte, err error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	a := &s.a
 	a.Name = v.Name
 	a.BirthDay = v.BirthDay
@@ -31,7 +33,7 @@ func (s *ColferSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
 		return
 	}
 
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	v.Name = a.Name
 	v.BirthDay = a.BirthDay
 	v.Phone = a.Phone

--- a/easyjson.go
+++ b/easyjson.go
@@ -1,15 +1,41 @@
 package goserbench
 
-import easyjson "github.com/mailru/easyjson"
+import (
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
+	easyjson "github.com/mailru/easyjson"
+)
 
-type EasyJSONSerializer struct{}
+type EasyJSONSerializer struct {
+	a A
+}
 
 func (m EasyJSONSerializer) Marshal(o interface{}) ([]byte, error) {
-	return easyjson.Marshal(o.(easyjson.Marshaler))
+	v := o.(*goserbench.SmallStruct)
+	a := &m.a
+	a.Name = v.Name
+	a.BirthDay = v.BirthDay
+	a.Phone = v.Phone
+	a.Siblings = v.Siblings
+	a.Spouse = v.Spouse
+	a.Money = v.Money
+	return easyjson.Marshal(a)
 }
 
 func (m EasyJSONSerializer) Unmarshal(d []byte, o interface{}) error {
-	return easyjson.Unmarshal(d, o.(*A))
+	a := &m.a
+	err := easyjson.Unmarshal(d, a)
+	if err != nil {
+		return err
+	}
+
+	v := o.(*goserbench.SmallStruct)
+	v.Name = a.Name
+	v.BirthDay = a.BirthDay
+	v.Phone = a.Phone
+	v.Siblings = int(a.Siblings)
+	v.Spouse = a.Spouse
+	v.Money = a.Money
+	return nil
 }
 
 func NewEasyJSONSerializer() Serializer {

--- a/fastjson.go
+++ b/fastjson.go
@@ -3,6 +3,7 @@ package goserbench
 import (
 	"time"
 
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 	"github.com/valyala/fastjson"
 )
 
@@ -13,7 +14,7 @@ type FastJSONSerializer struct {
 }
 
 func (s *FastJSONSerializer) Marshal(o interface{}) (buf []byte, err error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	object, arena := s.object, s.arena
 	object.Set("name", arena.NewString(v.Name))
 	object.Set("birthday", arena.NewNumberInt(int(v.BirthDay.UnixNano())))
@@ -31,7 +32,7 @@ func (s *FastJSONSerializer) Marshal(o interface{}) (buf []byte, err error) {
 }
 
 func (s *FastJSONSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	val, err := fastjson.ParseBytes(bs)
 	if err != nil {
 		return err

--- a/flatbuffers.go
+++ b/flatbuffers.go
@@ -3,6 +3,7 @@ package goserbench
 import (
 	"time"
 
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 	flatbuffers "github.com/google/flatbuffers/go"
 )
 
@@ -11,7 +12,7 @@ type FlatBufferSerializer struct {
 }
 
 func (s *FlatBufferSerializer) Marshal(o interface{}) ([]byte, error) {
-	a := o.(*A)
+	a := o.(*goserbench.SmallStruct)
 	builder := s.builder
 	builder.Bytes = nil // free
 	builder.Reset()
@@ -31,7 +32,7 @@ func (s *FlatBufferSerializer) Marshal(o interface{}) ([]byte, error) {
 }
 
 func (s *FlatBufferSerializer) Unmarshal(d []byte, i interface{}) error {
-	a := i.(*A)
+	a := i.(*goserbench.SmallStruct)
 	o := FlatBufferA{}
 	o.Init(d, flatbuffers.GetUOffsetT(d))
 	a.Name = string(o.Name())

--- a/gencode.go
+++ b/gencode.go
@@ -1,6 +1,10 @@
 package goserbench
 
-import "time"
+import (
+	"time"
+
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
+)
 
 type GencodeSerializer struct {
 	buf []byte
@@ -8,7 +12,7 @@ type GencodeSerializer struct {
 }
 
 func (s *GencodeSerializer) Marshal(o interface{}) ([]byte, error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	a := &s.a
 	a.Name = v.Name
 	a.BirthDay = v.BirthDay
@@ -26,7 +30,7 @@ func (s *GencodeSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
 		return
 	}
 
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	v.Name = a.Name
 	v.BirthDay = a.BirthDay
 	v.Phone = a.Phone
@@ -46,7 +50,7 @@ type GencodeUnsafeSerializer struct {
 }
 
 func (s *GencodeUnsafeSerializer) Marshal(o interface{}) ([]byte, error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	a := &s.a
 	a.Name = v.Name
 	a.BirthDay = v.BirthDay.UnixNano()
@@ -64,7 +68,7 @@ func (s *GencodeUnsafeSerializer) Unmarshal(bs []byte, o interface{}) (err error
 		return
 	}
 
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	v.Name = a.Name
 	v.BirthDay = time.Unix(0, a.BirthDay)
 	v.Phone = a.Phone

--- a/gogoprotobuf.go
+++ b/gogoprotobuf.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"time"
 
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 )
@@ -18,7 +19,7 @@ type GogoProtoSerializer struct {
 }
 
 func (s *GogoProtoSerializer) Marshal(o interface{}) (buf []byte, err error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	a := &s.a
 	a.Name = v.Name
 	a.BirthDay = v.BirthDay.UnixNano()
@@ -40,7 +41,7 @@ func (s *GogoProtoSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
 		return
 	}
 
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	v.Name = a.Name
 	v.BirthDay = time.Unix(0, a.BirthDay)
 	v.Phone = a.Phone

--- a/goserbench/goserbench.go
+++ b/goserbench/goserbench.go
@@ -1,0 +1,133 @@
+package goserbench
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+const (
+	// MaxSmallStructNameSize is the max size of a name used in the small
+	// struct benchmarks.
+	MaxSmallStructNameSize = 16
+
+	// MaxSmallStructPhoneSize is the max size of a phone used in the small
+	// struct benchmarks.
+	MaxSmallStructPhoneSize = 10
+)
+
+func randString(l int) string {
+	buf := make([]byte, l)
+	for i := 0; i < (l+1)/2; i++ {
+		buf[i] = byte(rand.Intn(256))
+	}
+	return fmt.Sprintf("%x", buf)[:l]
+}
+
+func generateSmallStruct() []*SmallStruct {
+	a := make([]*SmallStruct, 0, 1000)
+	for i := 0; i < 1000; i++ {
+		a = append(a, &SmallStruct{
+			Name:     randString(MaxSmallStructNameSize),
+			BirthDay: time.Now(),
+			Phone:    randString(MaxSmallStructPhoneSize),
+			Siblings: rand.Intn(5),
+			Spouse:   rand.Intn(2) == 1,
+			Money:    rand.Float64(),
+		})
+	}
+	return a
+}
+
+// BenchMarshalSmallStruct benchmarks marshalling the [SmallStruct] type.
+func BenchMarshalSmallStruct(b *testing.B, s Serializer) {
+	b.Helper()
+	data := generateSmallStruct()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var serialSize int
+	for i := 0; i < b.N; i++ {
+		o := data[rand.Intn(len(data))]
+		bytes, err := s.Marshal(o)
+		if err != nil {
+			b.Fatalf("marshal error %s for %#v", err, o)
+		}
+		serialSize += len(bytes)
+	}
+	b.ReportMetric(float64(serialSize)/float64(b.N), "B/serial")
+}
+
+// BenchUnmarshalSmallStruct benchmarks unmarshalling the [SmallStruct] type.
+// If validate is true, then the unmarshalled struct is verified to be correct
+// against the source struct.
+func BenchUnmarshalSmallStruct(b *testing.B, s Serializer, validate bool) {
+	b.Helper()
+
+	var timePrecision time.Duration
+	if stp, ok := s.(SerializerTimePrecision); ok {
+		timePrecision = stp.TimePrecision()
+	}
+	var forcesUTC bool
+	if set, ok := s.(SerializerEnforcesTimezone); ok {
+		forcesUTC = set.ForcesUTC()
+	}
+
+	data := generateSmallStruct()
+	ser := make([][]byte, len(data))
+	var serialSize int
+	for i, d := range data {
+		// Reduce the precision of the Birthday field when the
+		// serializer cannot represent time with nanosecond precision.
+		if timePrecision > 0 {
+			d.BirthDay = d.BirthDay.Truncate(timePrecision)
+		}
+
+		// Enforce Timezone when serializer requires it.
+		if forcesUTC {
+			d.BirthDay = d.BirthDay.UTC()
+		}
+
+		// Reduce precision of fractional fields when the serializer
+		// cannot represent the full float64 range.
+		if slfp, ok := s.(SerializerLimitsFloat64Precision); ok {
+			fracDigits := slfp.ReduceFloat64Precision()
+			i, f := math.Modf(d.Money)
+			power := math.Pow(10, float64(fracDigits))
+			newf := math.Trunc(f*power) / power
+			d.Money = float64(i) + newf
+		}
+
+		o, err := s.Marshal(d)
+		if err != nil {
+			b.Fatal(err)
+		}
+		t := make([]byte, len(o))
+		serialSize += copy(t, o)
+		ser[i] = t
+	}
+	o := &SmallStruct{}
+
+	b.ReportMetric(float64(serialSize)/float64(len(data)), "B/serial")
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		n := rand.Intn(len(ser))
+		*o = SmallStruct{}
+		err := s.Unmarshal(ser[n], o)
+		if err != nil {
+			b.Fatalf("unmarshal error %s for %#x / %q", err, ser[n], ser[n])
+		}
+		// Validate unmarshalled data.
+		if validate {
+			i := data[n]
+			correct := o.Name == i.Name && o.Phone == i.Phone && o.Siblings == i.Siblings && o.Spouse == i.Spouse && o.Money == i.Money && o.BirthDay.Equal(i.BirthDay) //&& cmpTags(o.Tags, i.Tags) && cmpAliases(o.Aliases, i.Aliases)
+			if !correct {
+				b.Fatalf("unmarshaled object differed:\n%v\n%v", i, o)
+			}
+		}
+	}
+}

--- a/goserbench/interface.go
+++ b/goserbench/interface.go
@@ -2,6 +2,16 @@ package goserbench
 
 import "time"
 
+// SmallStruct is a test structure of small size.
+type SmallStruct struct {
+	Name     string
+	BirthDay time.Time
+	Phone    string
+	Siblings int
+	Spouse   bool
+	Money    float64
+}
+
 // Serializer is the main interface for the serializer benchmarks.
 type Serializer interface {
 	// Marshal should marshal the given object (a *A) into a byte slice.

--- a/hprose.go
+++ b/hprose.go
@@ -3,6 +3,7 @@ package goserbench
 import (
 	"bytes"
 
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 	"github.com/hprose/hprose-go"
 )
 
@@ -12,7 +13,7 @@ type HproseSerializer struct {
 }
 
 func (s *HproseSerializer) Marshal(o interface{}) ([]byte, error) {
-	a := o.(*A)
+	a := o.(*goserbench.SmallStruct)
 	writer := s.writer
 	buf := writer.Stream.(*bytes.Buffer)
 	l := buf.Len()
@@ -26,7 +27,7 @@ func (s *HproseSerializer) Marshal(o interface{}) ([]byte, error) {
 }
 
 func (s *HproseSerializer) Unmarshal(d []byte, i interface{}) (err error) {
-	o := i.(*A)
+	o := i.(*goserbench.SmallStruct)
 	reader := s.reader
 	reader.Stream = &hprose.BytesReader{Bytes: d, Pos: 0}
 	o.Name, err = reader.ReadString()

--- a/hprose2.go
+++ b/hprose2.go
@@ -1,6 +1,7 @@
 package goserbench
 
 import (
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 	hprose2 "github.com/hprose/hprose-golang/io"
 )
 
@@ -10,7 +11,7 @@ type Hprose2Serializer struct {
 }
 
 func (s Hprose2Serializer) Marshal(o interface{}) ([]byte, error) {
-	a := o.(*A)
+	a := o.(*goserbench.SmallStruct)
 	writer := s.writer
 	writer.Clear()
 	writer.WriteString(a.Name)
@@ -23,7 +24,7 @@ func (s Hprose2Serializer) Marshal(o interface{}) ([]byte, error) {
 }
 
 func (s Hprose2Serializer) Unmarshal(d []byte, i interface{}) error {
-	o := i.(*A)
+	o := i.(*goserbench.SmallStruct)
 	reader := s.reader
 	reader.Init(d)
 	o.Name = reader.ReadString()

--- a/ike.go
+++ b/ike.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 	ikea "github.com/ikkerens/ikeapack"
 )
 
@@ -23,7 +24,7 @@ type IkeSerializer struct {
 }
 
 func (s *IkeSerializer) Marshal(o interface{}) (buf []byte, err error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	a := &s.a
 	a.Name = v.Name
 	a.BirthDay = v.BirthDay.UnixNano()
@@ -49,7 +50,7 @@ func (s *IkeSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
 		return
 	}
 
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	v.Name = a.Name
 	v.BirthDay = time.Unix(0, a.BirthDay)
 	v.Phone = a.Phone

--- a/msgp.go
+++ b/msgp.go
@@ -1,15 +1,39 @@
 package goserbench
 
-import "github.com/tinylib/msgp/msgp"
+import (
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
+)
 
-type MsgpSerializer struct{}
+type MsgpSerializer struct {
+	a A
+}
 
 func (m MsgpSerializer) Marshal(o interface{}) ([]byte, error) {
-	return o.(msgp.Marshaler).MarshalMsg(nil)
+	v := o.(*goserbench.SmallStruct)
+	a := &m.a
+	a.Name = v.Name
+	a.BirthDay = v.BirthDay
+	a.Phone = v.Phone
+	a.Siblings = v.Siblings
+	a.Spouse = v.Spouse
+	a.Money = v.Money
+	return a.MarshalMsg(nil)
 }
 
 func (m MsgpSerializer) Unmarshal(d []byte, o interface{}) error {
-	_, err := o.(msgp.Unmarshaler).UnmarshalMsg(d)
+	a := &m.a
+	_, err := a.UnmarshalMsg(d)
+	if err != nil {
+		return err
+	}
+
+	v := o.(*goserbench.SmallStruct)
+	v.Name = a.Name
+	v.BirthDay = a.BirthDay
+	v.Phone = a.Phone
+	v.Siblings = int(a.Siblings)
+	v.Spouse = a.Spouse
+	v.Money = a.Money
 	return err
 }
 

--- a/mus.go
+++ b/mus.go
@@ -3,6 +3,7 @@ package goserbench
 import (
 	"time"
 
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 	"github.com/mus-format/mus-go/ord"
 	"github.com/mus-format/mus-go/raw"
 	"github.com/mus-format/mus-go/unsafe"
@@ -12,7 +13,7 @@ import (
 type MUSSerializer struct{}
 
 func (s MUSSerializer) Marshal(o interface{}) ([]byte, error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	n := ord.SizeString(v.Name)
 	n += raw.SizeInt64(v.BirthDay.UnixNano())
 	n += ord.SizeString(v.Phone)
@@ -30,7 +31,7 @@ func (s MUSSerializer) Marshal(o interface{}) ([]byte, error) {
 }
 
 func (s MUSSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 
 	var n int
 
@@ -75,7 +76,7 @@ func NewMUSSerializer() Serializer {
 type MUSUnsafeSerializer struct{}
 
 func (s MUSUnsafeSerializer) Marshal(o interface{}) ([]byte, error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	n := unsafe.SizeString(v.Name)
 	n += unsafe.SizeInt64(v.BirthDay.UnixNano())
 	n += unsafe.SizeString(v.Phone)
@@ -94,7 +95,7 @@ func (s MUSUnsafeSerializer) Marshal(o interface{}) ([]byte, error) {
 
 func (s MUSUnsafeSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
 	var n int
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 
 	v.Name, n, err = unsafe.UnmarshalString(bs)
 	if err != nil {

--- a/pulsar.go
+++ b/pulsar.go
@@ -3,6 +3,7 @@ package goserbench
 import (
 	"time"
 
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 	pproto "google.golang.org/protobuf/proto"
 )
 
@@ -15,7 +16,7 @@ func (s *PulsarSerializer) ForceUTC() bool {
 }
 
 func (s *PulsarSerializer) Marshal(o interface{}) (buf []byte, err error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	a := &s.a
 	a.Name = v.Name
 	a.BirthDay = v.BirthDay.UnixNano()
@@ -37,7 +38,7 @@ func (s *PulsarSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
 		return
 	}
 
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	v.Name = a.Name
 	v.BirthDay = time.Unix(0, a.BirthDay)
 	v.Phone = a.Phone

--- a/shamaton.go
+++ b/shamaton.go
@@ -1,6 +1,7 @@
 package goserbench
 
 import (
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 	shamaton "github.com/shamaton/msgpack/v2"
 	shamatongen "github.com/shamaton/msgpackgen/msgpack"
 )
@@ -34,14 +35,37 @@ func NewShamatonArrayMsgPackSerializer() Serializer {
 	return ShamatonArrayMsgpackSerializer{}
 }
 
-type ShamatonMapMsgpackgenSerializer struct{}
+type ShamatonMapMsgpackgenSerializer struct {
+	a A
+}
 
 func (m ShamatonMapMsgpackgenSerializer) Marshal(o interface{}) ([]byte, error) {
-	return shamatongen.MarshalAsMap(o)
+	v := o.(*goserbench.SmallStruct)
+	a := &m.a
+	a.Name = v.Name
+	a.BirthDay = v.BirthDay
+	a.Phone = v.Phone
+	a.Siblings = v.Siblings
+	a.Spouse = v.Spouse
+	a.Money = v.Money
+	return shamatongen.MarshalAsMap(a)
 }
 
 func (m ShamatonMapMsgpackgenSerializer) Unmarshal(d []byte, o interface{}) error {
-	return shamatongen.UnmarshalAsMap(d, o)
+	a := &m.a
+	err := shamatongen.UnmarshalAsMap(d, a)
+	if err != nil {
+		return err
+	}
+
+	v := o.(*goserbench.SmallStruct)
+	v.Name = a.Name
+	v.BirthDay = a.BirthDay
+	v.Phone = a.Phone
+	v.Siblings = int(a.Siblings)
+	v.Spouse = a.Spouse
+	v.Money = a.Money
+	return nil
 }
 
 func NewShamatonMapMsgPackgenSerializer() Serializer {
@@ -49,15 +73,38 @@ func NewShamatonMapMsgPackgenSerializer() Serializer {
 	return ShamatonMapMsgpackgenSerializer{}
 }
 
-type ShamatonArrayMsgpackgenSerializer struct{}
+type ShamatonArrayMsgpackgenSerializer struct {
+	a A
+}
 
 func (m ShamatonArrayMsgpackgenSerializer) Marshal(o interface{}) ([]byte, error) {
-	return shamatongen.MarshalAsArray(o)
+	v := o.(*goserbench.SmallStruct)
+	a := &m.a
+	a.Name = v.Name
+	a.BirthDay = v.BirthDay
+	a.Phone = v.Phone
+	a.Siblings = v.Siblings
+	a.Spouse = v.Spouse
+	a.Money = v.Money
+	return shamatongen.MarshalAsArray(a)
 
 }
 
 func (m ShamatonArrayMsgpackgenSerializer) Unmarshal(d []byte, o interface{}) error {
-	return shamatongen.UnmarshalAsArray(d, o)
+	a := &m.a
+	err := shamatongen.UnmarshalAsArray(d, a)
+	if err != nil {
+		return err
+	}
+
+	v := o.(*goserbench.SmallStruct)
+	v.Name = a.Name
+	v.BirthDay = a.BirthDay
+	v.Phone = a.Phone
+	v.Siblings = int(a.Siblings)
+	v.Spouse = a.Spouse
+	v.Money = a.Money
+	return nil
 }
 
 func NewShamatonArrayMsgpackgenSerializer() Serializer {

--- a/ssz.go
+++ b/ssz.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 	ssz "github.com/prysmaticlabs/go-ssz"
 )
 
@@ -21,7 +22,7 @@ type SSZSerializer struct {
 }
 
 func (s *SSZSerializer) Marshal(o interface{}) (buf []byte, err error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	a := &s.a
 	a.Name = v.Name
 	a.BirthDay = uint64(v.BirthDay.UnixNano())
@@ -39,7 +40,7 @@ func (s *SSZSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
 		return
 	}
 
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	v.Name = a.Name
 	v.BirthDay = time.Unix(0, int64(a.BirthDay))
 	v.Phone = a.Phone

--- a/structdef_avro.go
+++ b/structdef_avro.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"time"
 
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 	goavro "github.com/linkedin/goavro"
 	goavro2 "github.com/linkedin/goavro/v2"
 )
@@ -69,7 +70,7 @@ func NewAvroA() Serializer {
 }
 
 func (a *AvroA) Marshal(o interface{}) ([]byte, error) {
-	object := o.(*A)
+	object := o.(*goserbench.SmallStruct)
 	a.record.Set("name", object.Name)
 	a.record.Set("birthday", int64(object.BirthDay.UnixNano()))
 	a.record.Set("phone", object.Phone)
@@ -84,7 +85,7 @@ func (a *AvroA) Marshal(o interface{}) ([]byte, error) {
 }
 
 func (a *AvroA) Unmarshal(d []byte, o interface{}) error {
-	object := o.(*A)
+	object := o.(*goserbench.SmallStruct)
 	b := bytes.NewBuffer(d)
 	i, err := a.codec.Decode(b)
 	if err != nil {
@@ -111,7 +112,7 @@ func (a *AvroA) String() string {
 }
 
 func avroMarshal(o interface{}, marshalFunc func([]byte, interface{}) ([]byte, error)) ([]byte, error) {
-	object := o.(*A)
+	object := o.(*goserbench.SmallStruct)
 	return marshalFunc(nil, map[string]interface{}{
 		"name":     object.Name,
 		"birthday": int64(object.BirthDay.UnixNano()),
@@ -123,7 +124,7 @@ func avroMarshal(o interface{}, marshalFunc func([]byte, interface{}) ([]byte, e
 }
 
 func avroUnmarshal(d []byte, o interface{}, unmarshalFunc func([]byte) (interface{}, []byte, error)) error {
-	object := o.(*A)
+	object := o.(*goserbench.SmallStruct)
 	r, _, err := unmarshalFunc(d)
 	if err != nil {
 		return err

--- a/xdr_calmh.go
+++ b/xdr_calmh.go
@@ -3,6 +3,8 @@ package goserbench
 import (
 	"math"
 	"time"
+
+	"github.com/alecthomas/go_serialization_benchmarks/goserbench"
 )
 
 type XDRCalmhSerializer struct {
@@ -10,7 +12,7 @@ type XDRCalmhSerializer struct {
 }
 
 func (s *XDRCalmhSerializer) Marshal(o interface{}) (buf []byte, err error) {
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	a := &s.a
 	a.Name = v.Name
 	a.BirthDay = v.BirthDay.UnixNano()
@@ -28,7 +30,7 @@ func (s *XDRCalmhSerializer) Unmarshal(bs []byte, o interface{}) (err error) {
 		return
 	}
 
-	v := o.(*A)
+	v := o.(*goserbench.SmallStruct)
 	v.Name = a.Name
 	v.BirthDay = time.Unix(0, a.BirthDay)
 	v.Phone = a.Phone


### PR DESCRIPTION
This moves the actual benchmarking code into a new, isolated package. Minimal changes are made to the existing serializers in order to keep the tests working.

In the future, this will allow moving each serializer into its own package, improving overall code organization and making it clearer what code is related to each serializer.

It will also allow creating a module out of the base benchmark code, which will allow third party code (e.g. serializer packages themselves) to run the same benchmark without having to be ported to this repository.