### PR TITLE
goserbench: Make this package a module 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/200sc/bebop v0.5.0
 	github.com/Sereal/Sereal v0.0.0-20230201113653-fa72c87b650e
 	github.com/alecthomas/binary v0.0.0-20221018225505-74871811ee56
+	github.com/alecthomas/go_serialization_benchmarks/goserbench v0.0.0
 	github.com/calmh/xdr v1.1.0
 	github.com/davecgh/go-xdr v0.0.0-20161123171359-e6a2ba005892
 	github.com/glycerine/go-capnproto v0.0.0-20190118050403-2d07de3aa7fc
@@ -18,8 +19,6 @@ require (
 	github.com/linkedin/goavro v1.0.5
 	github.com/linkedin/goavro/v2 v2.12.0
 	github.com/mailru/easyjson v0.7.7
-	github.com/mojura/enkodo v0.5.6
-	github.com/niubaoshu/gotiny v0.0.3
 	github.com/prysmaticlabs/go-ssz v0.0.0-20190827151743-72881c4223d8
 	github.com/shamaton/msgpack/v2 v2.1.1
 	github.com/shamaton/msgpackgen v0.3.0
@@ -34,15 +33,12 @@ require (
 	wellquite.org/bebop v0.0.0-20231109192402-a92af83691ec
 )
 
-require (
-	github.com/nazarifard/copi v0.0.0-20240609072615-763316f77579 // indirect
-	github.com/nazarifard/fastape v0.0.0-20240611084216-abaecf150e5b // indirect
-)
+replace github.com/alecthomas/go_serialization_benchmarks/goserbench => ./goserbench
 
 require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/cosmos/cosmos-proto v1.0.0-beta.3
-	github.com/cybriq/gotiny v0.0.5 // indirect
+	github.com/cybriq/gotiny v0.0.5
 	github.com/deneonet/benc v1.0.2
 	github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 // indirect
 	github.com/glycerine/rbtree v0.0.0-20190406191118-ceb71889d809 // indirect
@@ -59,6 +55,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mus-format/mus-common-go v0.0.0-20230426111652-d1324c6517b3 // indirect
 	github.com/mus-format/mus-go v0.0.0-20230426134740-6572513fca3d
+	github.com/nazarifard/fastape v0.0.0-20240611084216-abaecf150e5b
 	github.com/philhofer/fwd v1.1.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/protolambda/zssz v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cybriq/gotiny v0.0.5 h1:VgEZDiDXaObPVhK9O+JNM6USguc+vUsz4dLMIMhuL7M=
 github.com/cybriq/gotiny v0.0.5/go.mod h1:u13//tC09EgkQTDqXZrf6bNI9cc9dr07ZqUVQreubzk=
-github.com/cybriq/gotiny v0.0.6-0.20220412231127-0a1864225fc8 h1:R/4a3XWWW1uXKNRbMXUTmnWpJAyMc+NUhT2+uf7oq3Q=
-github.com/cybriq/gotiny v0.0.6-0.20220412231127-0a1864225fc8/go.mod h1:u13//tC09EgkQTDqXZrf6bNI9cc9dr07ZqUVQreubzk=
 github.com/dave/jennifer v1.4.1/go.mod h1:7jEdnm+qBcxl8PC0zyp7vxcpSRnzXSt9r39tpTVGlwA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -195,16 +193,12 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/mojura/enkodo v0.5.6 h1:aISGI1RkecsER0HwgQLENa0g+j1ywUTq8fwoheBPcdQ=
-github.com/mojura/enkodo v0.5.6/go.mod h1:9/1bBkNTRhwLPSFAo0uG1a+numnsZMxNIzLdWxlFl+g=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/mus-format/mus-common-go v0.0.0-20230426111652-d1324c6517b3 h1:iGDJid8cb5Yt/pa1M/JEMC8u+Zkzv3WU6AKNOHtY/14=
 github.com/mus-format/mus-common-go v0.0.0-20230426111652-d1324c6517b3/go.mod h1:sL9Q5xrbsrFJ0WQRvf7/Ji1ljR3p8TrywHj0hQBscsc=
 github.com/mus-format/mus-go v0.0.0-20230426134740-6572513fca3d h1:/FqtbOoougvCbsp769ZZxgN3Pj/fepBAr4ETQXM+uwQ=
 github.com/mus-format/mus-go v0.0.0-20230426134740-6572513fca3d/go.mod h1:zdDnTFri6XqdQVRTE/HuGnmn+/3c3a0ODNUsw+9SXS8=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nazarifard/copi v0.0.0-20240609072615-763316f77579 h1:toqD8/J9DygfET+HZRsIu4kLUz32E4qcUhR1USRNPrY=
-github.com/nazarifard/copi v0.0.0-20240609072615-763316f77579/go.mod h1:RZX6PlUi+vF52MjBneuJcoszjuejOPWdMnAKaJOccGc=
 github.com/nazarifard/fastape v0.0.0-20240611084216-abaecf150e5b h1:Roh7HBLqAxLpo/qxWztQlzt6QUBGTCX9AXxCaJf+pB8=
 github.com/nazarifard/fastape v0.0.0-20240611084216-abaecf150e5b/go.mod h1:F54tpGg4uMgsYNUqD07iNENNGcS2GJobr+td/iZ5Xm4=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
@@ -245,6 +239,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/sanity-io/litter v1.5.5 h1:iE+sBxPBzoK6uaEP5Lt3fHNgpKcHXc/A2HGETy0uJQo=
+github.com/sanity-io/litter v1.5.5/go.mod h1:9gzJgR2i4ZpjZHsKvUXIRQVk7P+yM3e+jAF7bU2UI5U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shamaton/msgpack/v2 v2.1.0/go.mod h1:aTUEmh31ziGX1Ml7wMPLVY0f4vT3CRsCvZRoSCs+VGg=
 github.com/shamaton/msgpack/v2 v2.1.1 h1:gAMxOtVJz93R0EwewwUc8tx30n34aV6BzJuwHE8ogAk=
@@ -275,8 +271,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/goserbench/go.mod
+++ b/goserbench/go.mod
@@ -1,0 +1,3 @@
+module github.com/alecthomas/go_serialization_benchmarks/goserbench
+
+go 1.19

--- a/goserbench/goserbench.go
+++ b/goserbench/goserbench.go
@@ -124,9 +124,20 @@ func BenchUnmarshalSmallStruct(b *testing.B, s Serializer, validate bool) {
 		// Validate unmarshalled data.
 		if validate {
 			i := data[n]
-			correct := o.Name == i.Name && o.Phone == i.Phone && o.Siblings == i.Siblings && o.Spouse == i.Spouse && o.Money == i.Money && o.BirthDay.Equal(i.BirthDay) //&& cmpTags(o.Tags, i.Tags) && cmpAliases(o.Aliases, i.Aliases)
-			if !correct {
-				b.Fatalf("unmarshaled object differed:\n%v\n%v", i, o)
+			if o.Name != i.Name {
+				b.Fatalf("wrong name: got %q, want %q", o.Name, i.Name)
+			}
+			if o.Phone != i.Phone {
+				b.Fatalf("wrong phone: got %q, want %q", o.Phone, i.Phone)
+			}
+			if o.Siblings != i.Siblings {
+				b.Fatalf("wrong siblings: got %v, want %v", o.Siblings, i.Siblings)
+			}
+			if o.Spouse != i.Spouse {
+				b.Fatalf("wrong spouse : got %v, want %v", o.Spouse, i.Spouse)
+			}
+			if !o.BirthDay.Equal(i.BirthDay) {
+				b.Fatalf("wrong birthday: got %v, want %v", o.BirthDay, i.BirthDay)
 			}
 		}
 	}


### PR DESCRIPTION
This makes the goserbench package into its own module. This allows third
parties to import the main benchmark procedure without having to require
any of the tested serializers.

The goal of this split is to allow serializer projects to themselves
import the benchmark code to ease development and verification of the
benchmark numbers, without having to depend upon any of the other
serializers tested in this repository.

The main go.mod file is modified to ensure running the benchmarks
locally always uses the local version of the goserbench package. This
commit also tidies the go.mod and go.sum file.

After this is merged to the master branch, a new tag can be created (such as `goserbench/v0.1.0`) to ensure users can require a stable version of the new goserbench module.