### PR TITLE
Remove invalid disclaimer from ikeapack

### DIFF
--- a/internal/serializers/ikea/ikea.go
+++ b/internal/serializers/ikea/ikea.go
@@ -15,7 +15,7 @@ type IkeA struct {
 	Phone    string
 	Siblings int32
 	Spouse   bool
-	Money    uint64 // NOTE: Ike does not support float64 - it needs to be converted to an int type.
+	Money    uint64
 }
 
 type IkeaSerializer struct {


### PR DESCRIPTION
I'm not sure why this comment was added, but it is not correct, ikeapack supports float32/float64 just fine, and always has.

The reason why I didn't use float64 for a field called Money is because using float for Money is not a good idea, and I was a little cheeky at the time :)