### PR TITLE
Publishing Report to Github Pages

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,0 +1,18 @@
+name: Publish Report
+on: [push, pull_request]
+
+jobs:
+  publish:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Publish report to GitHub Pages
+        uses: rayluo/github-pages-overwriter@v1.3
+
+        with:
+          source-directory: report
+          target-branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a test suite for benchmarking various Go serialization methods.
 
 # Current Serialization Results
 
-http://htmlpreview.github.io/?https://github.com/alecthomas/go_serialization_benchmarks/report/index.html
+http://alecthomas.github.io/go_serialization_benchmarks
 
 ## Running the benchmarks
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a test suite for benchmarking various Go serialization methods.
 
 # Current Serialization Results
 
-http://alecthomas.github.io/go_serialization_benchmarks
+https://alecthomas.github.io/go_serialization_benchmarks
 
 ## Running the benchmarks
 


### PR DESCRIPTION
Instead of using `html-previewer`, I added a github action to automatically put the contents from the report folder into the `gh-pages` branch, then the report also shows up on all browsers.