### PR TITLE
two new scripts are added. benchmark.sh genreport_test.sh

### DIFF
--- a/algname_test.go
+++ b/algname_test.go
@@ -1,0 +1,2 @@
+package goserbench
+const ALG_NAME = "msgpack"

--- a/benchmarks.sh
+++ b/benchmarks.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+for f in `sed s://.*:: benchmarks.go |awk '/Name:/{print $2}'|sed s/[,]//g`; do 
+   echo "package goserbench" > algname_test.go; 
+   echo "const ALG_NAME = $f" >> algname_test.go; 
+   go test -bench=. -benchmem| grep BenchmarkSerializers| sed s:BenchmarkSerializers/::; 
+done
+echo "package goserbench" > algname_test.go; 
+echo "const ALG_NAME = \"any\"" >> algname_test.go; 
+
+
+

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -23,6 +23,9 @@ See README.md for details on running the benchmarks.
 func BenchmarkSerializers(b *testing.B) {
 	for i := range benchmarkCases {
 		bc := benchmarkCases[i]
+		if ALG_NAME != "any" && bc.Name != ALG_NAME {
+			continue
+		}
 		b.Run("marshal/"+bc.Name, func(b *testing.B) {
 			goserbench.BenchMarshalSmallStruct(b, bc.New())
 		})

--- a/genreport_test.go
+++ b/genreport_test.go
@@ -42,6 +42,9 @@ type reportLine struct {
 func generateReport() error {
 	data := make([]reportLine, len(benchmarkCases))
 	for i, bench := range benchmarkCases {
+		if ALG_NAME != "any" && bench.Name != ALG_NAME {
+			continue
+		}
 		marshalRes := testing.Benchmark(func(b *testing.B) {
 			goserbench.BenchMarshalSmallStruct(b, bench.New())
 		})

--- a/genreport_test.sh
+++ b/genreport_test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+rm -f /tmp/temp_report.js
+for f in `sed s://.*:: benchmarks.go |awk '/Name:/{print $2}'|sed s/[,]//g`; do 
+   echo "package goserbench" > algname_test.go; 
+   echo "const ALG_NAME = $f" >> algname_test.go; 
+   go test -tags genreport -run TestGenerateReport
+   lines=`wc -l ./report/data.js|awk '{print $1;}'`
+   tail -$(($lines)) ./report/data.js|head -$(($lines-2))  >> /tmp/temp_report.js
+   echo -e "\t}," >> /tmp/temp_report.js
+done
+
+lines=`wc -l /tmp/temp_report.js|awk '{print $1;}'`
+echo "var data = [" > report/data.js
+head -$(($lines-2)) /tmp/temp_report.js  >> ./report/data.js
+echo -e "\t}" >> ./report/data.js
+echo -n "];" >> ./report/data.js
+rm -f /tmp/temp_report.js
+
+
+echo "package goserbench" > algname_test.go; 
+echo "const ALG_NAME = \"any\"" >> algname_test.go; 
+   


### PR DESCRIPTION
Based on my tests high order algorithms often (not always) have more chance than others.
I developed two scripts benchmarks.sh  and genreport_test.sh that runs "go test" per algorithm separately and finally concatenates all results.
Obviously it does not have impact on default functionality and it will work as same as old without any change.
