### PR TITLE
go.mod: Tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,11 @@ require (
 	github.com/Sereal/Sereal v0.0.0-20230201113653-fa72c87b650e
 	github.com/alecthomas/binary v0.0.0-20221018225505-74871811ee56
 	github.com/calmh/xdr v1.1.0
+	github.com/chmike/ditp v0.0.0-20240618130435-627cf7ce9ad6
+	github.com/cosmos/cosmos-proto v1.0.0-beta.3
+	github.com/cybriq/gotiny v0.0.5
 	github.com/davecgh/go-xdr v0.0.0-20161123171359-e6a2ba005892
+	github.com/deneonet/benc v1.0.2
 	github.com/glycerine/go-capnproto v0.0.0-20190118050403-2d07de3aa7fc
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/flatbuffers v23.1.21+incompatible
@@ -18,8 +22,7 @@ require (
 	github.com/linkedin/goavro v1.0.5
 	github.com/linkedin/goavro/v2 v2.12.0
 	github.com/mailru/easyjson v0.7.7
-	github.com/mojura/enkodo v0.5.6
-	github.com/niubaoshu/gotiny v0.0.3
+	github.com/nazarifard/fastape v0.0.0-20240611084216-abaecf150e5b
 	github.com/prysmaticlabs/go-ssz v0.0.0-20190827151743-72881c4223d8
 	github.com/shamaton/msgpack/v2 v2.1.1
 	github.com/shamaton/msgpackgen v0.3.0
@@ -35,16 +38,7 @@ require (
 )
 
 require (
-	github.com/chmike/ditp v0.0.0-20240618130435-627cf7ce9ad6 // indirect
-	github.com/nazarifard/copi v0.0.0-20240609072615-763316f77579 // indirect
-	github.com/nazarifard/fastape v0.0.0-20240611084216-abaecf150e5b // indirect
-)
-
-require (
 	github.com/DataDog/zstd v1.5.2 // indirect
-	github.com/cosmos/cosmos-proto v1.0.0-beta.3
-	github.com/cybriq/gotiny v0.0.5 // indirect
-	github.com/deneonet/benc v1.0.2
 	github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 // indirect
 	github.com/glycerine/rbtree v0.0.0-20190406191118-ceb71889d809 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
@@ -67,10 +61,4 @@ require (
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-)
-
-replace (
-	github.com/itsmontoya/mum v0.5.6 => github.com/mojura/enkodo v0.5.6
-	github.com/niubaoshu/gotiny v0.0.3 => github.com/cybriq/gotiny v0.0.6-0.20220412231127-0a1864225fc8
-	github.com/stretchrcom/testify v1.7.1 => github.com/stretchr/testify v1.7.1
 )

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cybriq/gotiny v0.0.5 h1:VgEZDiDXaObPVhK9O+JNM6USguc+vUsz4dLMIMhuL7M=
 github.com/cybriq/gotiny v0.0.5/go.mod h1:u13//tC09EgkQTDqXZrf6bNI9cc9dr07ZqUVQreubzk=
-github.com/cybriq/gotiny v0.0.6-0.20220412231127-0a1864225fc8 h1:R/4a3XWWW1uXKNRbMXUTmnWpJAyMc+NUhT2+uf7oq3Q=
-github.com/cybriq/gotiny v0.0.6-0.20220412231127-0a1864225fc8/go.mod h1:u13//tC09EgkQTDqXZrf6bNI9cc9dr07ZqUVQreubzk=
 github.com/dave/jennifer v1.4.1/go.mod h1:7jEdnm+qBcxl8PC0zyp7vxcpSRnzXSt9r39tpTVGlwA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -197,16 +195,12 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/mojura/enkodo v0.5.6 h1:aISGI1RkecsER0HwgQLENa0g+j1ywUTq8fwoheBPcdQ=
-github.com/mojura/enkodo v0.5.6/go.mod h1:9/1bBkNTRhwLPSFAo0uG1a+numnsZMxNIzLdWxlFl+g=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/mus-format/mus-common-go v0.0.0-20230426111652-d1324c6517b3 h1:iGDJid8cb5Yt/pa1M/JEMC8u+Zkzv3WU6AKNOHtY/14=
 github.com/mus-format/mus-common-go v0.0.0-20230426111652-d1324c6517b3/go.mod h1:sL9Q5xrbsrFJ0WQRvf7/Ji1ljR3p8TrywHj0hQBscsc=
 github.com/mus-format/mus-go v0.0.0-20230426134740-6572513fca3d h1:/FqtbOoougvCbsp769ZZxgN3Pj/fepBAr4ETQXM+uwQ=
 github.com/mus-format/mus-go v0.0.0-20230426134740-6572513fca3d/go.mod h1:zdDnTFri6XqdQVRTE/HuGnmn+/3c3a0ODNUsw+9SXS8=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nazarifard/copi v0.0.0-20240609072615-763316f77579 h1:toqD8/J9DygfET+HZRsIu4kLUz32E4qcUhR1USRNPrY=
-github.com/nazarifard/copi v0.0.0-20240609072615-763316f77579/go.mod h1:RZX6PlUi+vF52MjBneuJcoszjuejOPWdMnAKaJOccGc=
 github.com/nazarifard/fastape v0.0.0-20240611084216-abaecf150e5b h1:Roh7HBLqAxLpo/qxWztQlzt6QUBGTCX9AXxCaJf+pB8=
 github.com/nazarifard/fastape v0.0.0-20240611084216-abaecf150e5b/go.mod h1:F54tpGg4uMgsYNUqD07iNENNGcS2GJobr+td/iZ5Xm4=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
@@ -247,6 +241,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/sanity-io/litter v1.5.5 h1:iE+sBxPBzoK6uaEP5Lt3fHNgpKcHXc/A2HGETy0uJQo=
+github.com/sanity-io/litter v1.5.5/go.mod h1:9gzJgR2i4ZpjZHsKvUXIRQVk7P+yM3e+jAF7bU2UI5U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shamaton/msgpack/v2 v2.1.0/go.mod h1:aTUEmh31ziGX1Ml7wMPLVY0f4vT3CRsCvZRoSCs+VGg=
 github.com/shamaton/msgpack/v2 v2.1.1 h1:gAMxOtVJz93R0EwewwUc8tx30n34aV6BzJuwHE8ogAk=
@@ -277,8 +273,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
Remove unnecessary references and replacement directives.

Format the file according to the current standard formatting for go.mod files (2 sections, first with direct requirements and the second with indirect ones).