### PR TITLE
report: Add notice about the report being user-generated

### DIFF
--- a/report/index.html
+++ b/report/index.html
@@ -22,6 +22,10 @@
     		<link href="custom.css" rel="stylesheet" />
 	</head>
 	<body>
+		<p><i>
+			Note: This report is user-generated. For best comparison 
+			results, re-run it on your target architecture/platform.
+		</i></p>
 		<div id="grid_json"></div>
 		<script>
 			$(function(){


### PR DESCRIPTION
The idea is to make it clear the results could be biased by architecture/platform or by the submitter (for example, by having it run concurrently to other workloads).